### PR TITLE
Re-enable macOS Tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,24 +31,22 @@ jobs:
       env:
           WORKING_DIRECTORY: Sources
 
-# re-enable when macOS 12 is available
-#
-#  macOSBuild:
-#    name: macOS - Latest Stable Xcode
-#    runs-on: macOS-latest
-#        
-#    steps:
-#      - name: Configure Xcode
-#        uses: maxim-lobanov/setup-xcode@v1
-#        with:
-#          xcode-version: 'latest-stable'
-#      - name: Checkout
-#        uses: actions/checkout@v1
-#      - name: Swift Package Information
-#        run: |
-#          swift --version
-#          swift package show-dependencies
-#      - name: Build
-#        run: swift build --build-tests
-#      - name: Test
-#        run: swift test
+  macOSBuild:
+    name: macOS - Latest Stable Xcode
+    runs-on: macOS-latest
+        
+    steps:
+      - name: Configure Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 'latest-stable'
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Swift Package Information
+        run: |
+          swift --version
+          swift package show-dependencies
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test


### PR DESCRIPTION
WIth Xcode 13.2, concurrency no longer requires macOS 12 or later, and can run on 10.15 or later. So we should be able to run the tests against Big Sur with the latest Xcode.