### PR TITLE
Enabling backing up extra folders

### DIFF
--- a/Sources/Bedrockifier/Commands/BackupCommand.swift
+++ b/Sources/Bedrockifier/Commands/BackupCommand.swift
@@ -109,11 +109,12 @@ public final class BackupCommand: Command {
 
                 // Run optional trim
                 if signature.trim {
-                    try WorldBackup.trimBackups(at: backupUrl,
-                                                dryRun: false,
-                                                trimDays: signature.keepDays,
-                                                keepDays: signature.keepDays,
-                                                minKeep: signature.minKeep)
+                    try Backups.trimBackups(World.self,
+                                            at: backupUrl,
+                                            dryRun: false,
+                                            trimDays: signature.keepDays,
+                                            keepDays: signature.keepDays,
+                                            minKeep: signature.minKeep)
                 }
             } catch let error {
                 Library.log.error("\(error.localizedDescription)")

--- a/Sources/Bedrockifier/Commands/BackupCommand.swift
+++ b/Sources/Bedrockifier/Commands/BackupCommand.swift
@@ -99,7 +99,8 @@ public final class BackupCommand: Command {
                 let connection = try ContainerConnection(dockerPath: signature.dockerPath,
                                                          containerName: signature.containerName,
                                                          kind: .bedrock,
-                                                         worlds: worldsPaths)
+                                                         worlds: worldsPaths,
+                                                         extras: nil)
 
                 // Run Backup
                 try connection.start()

--- a/Sources/Bedrockifier/Commands/BackupJobCommand.swift
+++ b/Sources/Bedrockifier/Commands/BackupJobCommand.swift
@@ -112,16 +112,23 @@ public final class BackupJobCommand: Command {
 
                 if let ownershipConfig = config.ownership {
                     Library.log.info("Performing Ownership Fixup")
-                    try WorldBackup.fixOwnership(at: backupUrl, config: ownershipConfig)
+                    try Backups.fixOwnership(at: backupUrl, config: ownershipConfig)
                 }
 
                 if let trimJob = config.trim {
                     Library.log.info("Performing Trim Jobs")
-                    try WorldBackup.trimBackups(at: backupUrl,
-                                                dryRun: false,
-                                                trimDays: trimJob.trimDays,
-                                                keepDays: trimJob.keepDays,
-                                                minKeep: trimJob.minKeep)
+                    try Backups.trimBackups(World.self,
+                                            at: backupUrl,
+                                            dryRun: false,
+                                            trimDays: trimJob.trimDays,
+                                            keepDays: trimJob.keepDays,
+                                            minKeep: trimJob.minKeep)
+                    try Backups.trimBackups(ServerExtras.self,
+                                            at: backupUrl,
+                                            dryRun: false,
+                                            trimDays: trimJob.trimDays,
+                                            keepDays: trimJob.keepDays,
+                                            minKeep: trimJob.minKeep)
                 }
             } catch let error {
                 Library.log.error("\(error.localizedDescription)")

--- a/Sources/Bedrockifier/Commands/TrimCommand.swift
+++ b/Sources/Bedrockifier/Commands/TrimCommand.swift
@@ -55,10 +55,17 @@ public final class TrimCommand: Command {
     public func run(using context: CommandContext, signature: Signature) throws {
         let backupFolderUrl = URL(fileURLWithPath: signature.backupFolderPath, isDirectory: true)
 
-        try WorldBackup.trimBackups(at: backupFolderUrl,
-                                    dryRun: signature.dryRun,
-                                    trimDays: signature.trimDays,
-                                    keepDays: signature.keepDays,
-                                    minKeep: signature.minKeep)
+        try Backups.trimBackups(World.self,
+                                at: backupFolderUrl,
+                                dryRun: signature.dryRun,
+                                trimDays: signature.trimDays,
+                                keepDays: signature.keepDays,
+                                minKeep: signature.minKeep)
+        try Backups.trimBackups(ServerExtras.self,
+                                at: backupFolderUrl,
+                                dryRun: signature.dryRun,
+                                trimDays: signature.trimDays,
+                                keepDays: signature.keepDays,
+                                minKeep: signature.minKeep)
     }
 }

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -42,6 +42,7 @@ public struct BackupConfig: Codable {
 
     public struct ContainerConfig: Codable {
         public var name: String
+        public var extras: [String]?
         public var worlds: [String]
     }
 

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -185,13 +185,11 @@ public class ContainerConnection {
         for extra in extras {
             Library.log.info("Packing \(extra.lastPathComponent)...")
             let dirEnum = FileManager.default.enumerator(atPath: extra.path)
-            let parentFolder = URL(fileURLWithPath: extra.lastPathComponent)
-
+            let folderBase = NSString(string: extra.lastPathComponent)
             while let archiveItem = dirEnum?.nextObject() as? String {
+                let archivePath = String(folderBase.appendingPathComponent(archiveItem))
                 let fullItemUrl = URL(fileURLWithPath: archiveItem, relativeTo: extra)
-                let archivePath = URL(fileURLWithPath: archiveItem, relativeTo: parentFolder)
-                Library.log.trace("Packing: \(archiveItem) <- \(fullItemUrl.path)")
-                try archive.addEntry(with: archivePath.path, fileURL: fullItemUrl)
+                try archive.addEntry(with: archivePath, fileURL: fullItemUrl)
             }
         }
 

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import PTYKit
+import ZIPFoundation
 
 private let usePty = false
 
@@ -26,6 +27,7 @@ public class ContainerConnection {
     public let terminal: PseudoTerminal
     var dockerProcess: Process
     let worlds: [URL]
+    let extras: [URL]?
     var playerCount: Int
     public var lastBackup: Date
 
@@ -33,12 +35,14 @@ public class ContainerConnection {
                 dockerPath: String,
                 containerName: String,
                 kind: Kind,
-                worlds: [String]) throws {
+                worlds: [String],
+                extras: [String]?) throws {
         self.dockerPath = dockerPath
         self.name = containerName
         self.kind = kind
         self.terminal = terminal
         self.worlds = worlds.map({ URL(fileURLWithPath: $0) })
+        self.extras = extras?.map({ URL(fileURLWithPath: $0) })
         self.playerCount = 0
         self.lastBackup = .distantPast
 
@@ -47,13 +51,14 @@ public class ContainerConnection {
         self.dockerProcess = try Process(processUrl, arguments: processArgs, terminal: self.terminal)
     }
 
-    public convenience init(dockerPath: String, containerName: String, kind: Kind, worlds: [String]) throws {
+    public convenience init(dockerPath: String, containerName: String, kind: Kind, worlds: [String], extras: [String]?) throws {
         let terminal = try PseudoTerminal()
         try self.init(terminal: terminal,
                       dockerPath: dockerPath,
                       containerName: containerName,
                       kind: kind,
-                      worlds: worlds)
+                      worlds: worlds,
+                      extras: extras)
     }
 
     public func start() throws {
@@ -108,6 +113,19 @@ public class ContainerConnection {
             }
         }
 
+        if let extras = extras {
+            Library.log.info("Backing up extras for \(name)")
+            do {
+                let fileName = try backupExtras(destination: destination, extras: extras)
+
+                Library.log.info("Backed up extras as \(fileName)")
+            } catch let error {
+                Library.log.error("\(error.localizedDescription)")
+                Library.log.error("Backup of \(name) extras failed.")
+                failedBackups.append("\(name) extras")
+            }
+        }
+
         lastBackup = Date()
         if failedBackups.count > 0 {
             Library.log.error("Backups for \(name) had failures...")
@@ -148,6 +166,33 @@ public class ContainerConnection {
     public func decrementPlayerCount() -> Int {
         playerCount = max(0, playerCount - 1)
         return playerCount
+    }
+
+    private func backupExtras(destination: URL, extras: [URL]) throws -> String {
+        let timestamp = DateFormatter.backupDateFormatter.string(from: Date())
+        let fileName = "\(name).extras.\(timestamp).zip"
+        let archivePath = destination.appendingPathComponent(fileName)
+
+        try FileManager.default.createDirectory(atPath: destination.path,
+                                                withIntermediateDirectories: true,
+                                                attributes: nil)
+
+        guard let archive = Archive(url: archivePath, accessMode: .create) else {
+            throw ContainerError.invalidExtrasArchive
+        }
+
+        for extra in extras {
+            Library.log.info("Packing \(extra.lastPathComponent)...")
+            let dirEnum = FileManager.default.enumerator(atPath: extra.path)
+            let parentFolder = extra.deletingLastPathComponent()
+
+            while let archiveItem = dirEnum?.nextObject() as? String {
+                let fullItemUrl = URL(fileURLWithPath: archiveItem, relativeTo: parentFolder)
+                try archive.addEntry(with: archiveItem, fileURL: fullItemUrl)
+            }
+        }
+
+        return fileName
     }
 
     private func pauseSaveOnBedrock() async throws {
@@ -259,7 +304,8 @@ extension ContainerConnection {
             let connection = try ContainerConnection(dockerPath: dockerPath,
                                                      containerName: container.name,
                                                      kind: .bedrock,
-                                                     worlds: container.worlds)
+                                                     worlds: container.worlds,
+                                                     extras: container.extras)
             containers.append(connection)
         }
 
@@ -267,7 +313,8 @@ extension ContainerConnection {
             let connection = try ContainerConnection(dockerPath: dockerPath,
                                                      containerName: container.name,
                                                      kind: .java,
-                                                     worlds: container.worlds)
+                                                     worlds: container.worlds,
+                                                     extras: container.extras)
             containers.append(connection)
         }
 
@@ -280,7 +327,8 @@ extension ContainerConnection {
             let connection = try ContainerConnection(dockerPath: dockerPath,
                                                      containerName: containerName,
                                                      kind: .bedrock,
-                                                     worlds: worldPaths)
+                                                     worlds: worldPaths,
+                                                     extras: nil)
             containers.append(connection)
         }
 
@@ -296,6 +344,7 @@ extension ContainerConnection {
         case saveNotCompleted
         case resumeFailed
         case backupsFailed([String])
+        case invalidExtrasArchive
     }
 }
 
@@ -315,6 +364,8 @@ extension ContainerConnection.ContainerError: LocalizedError {
         case .backupsFailed(let worlds):
             let worldsString = worlds.joined(separator: ", ")
             return "Server container had worlds that failed to backup: \(worldsString)"
+        case .invalidExtrasArchive:
+            return "Could not create ZIP archive for extras"
         }
     }
 }

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -172,6 +172,7 @@ public class ContainerConnection {
         let timestamp = DateFormatter.backupDateFormatter.string(from: Date())
         let fileName = "\(name).extras.\(timestamp).zip"
         let archivePath = destination.appendingPathComponent(fileName)
+        Library.log.trace("Extras destination: \(archivePath.path)")
 
         try FileManager.default.createDirectory(atPath: destination.path,
                                                 withIntermediateDirectories: true,
@@ -188,6 +189,7 @@ public class ContainerConnection {
 
             while let archiveItem = dirEnum?.nextObject() as? String {
                 let fullItemUrl = URL(fileURLWithPath: archiveItem, relativeTo: parentFolder)
+                Library.log.trace("Packing: \(archiveItem) -> \(fullItemUrl.path)")
                 try archive.addEntry(with: archiveItem, fileURL: fullItemUrl)
             }
         }

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -185,12 +185,13 @@ public class ContainerConnection {
         for extra in extras {
             Library.log.info("Packing \(extra.lastPathComponent)...")
             let dirEnum = FileManager.default.enumerator(atPath: extra.path)
-            let parentFolder = extra.deletingLastPathComponent()
+            let parentFolder = URL(fileURLWithPath: extra.lastPathComponent)
 
             while let archiveItem = dirEnum?.nextObject() as? String {
-                let fullItemUrl = URL(fileURLWithPath: archiveItem, relativeTo: parentFolder)
-                Library.log.trace("Packing: \(archiveItem) -> \(fullItemUrl.path)")
-                try archive.addEntry(with: archiveItem, fileURL: fullItemUrl)
+                let fullItemUrl = URL(fileURLWithPath: archiveItem, relativeTo: extra)
+                let archivePath = URL(fileURLWithPath: archiveItem, relativeTo: parentFolder)
+                Library.log.trace("Packing: \(archiveItem) <- \(fullItemUrl.path)")
+                try archive.addEntry(with: archivePath.path, fileURL: fullItemUrl)
             }
         }
 

--- a/Sources/Bedrockifier/Model/ServerExtras.swift
+++ b/Sources/Bedrockifier/Model/ServerExtras.swift
@@ -1,0 +1,64 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+
+public struct ServerExtras: BackupItem {
+    public var name: String
+    public var location: URL
+
+    public init(url: URL) throws {
+        let fileName = url.lastPathComponent
+        let expression = try NSRegularExpression(pattern: "(.+?)\\.extras\\.(.+?)\\.zip", options: .caseInsensitive)
+        let range = NSRange(fileName.startIndex..<fileName.endIndex, in: fileName)
+        guard let match = expression.firstMatch(in: fileName, options: [], range: range) else {
+            throw ServerExtrasError.invalidArchive(url)
+        }
+
+        guard let nameRange = Range(match.range(at: 1), in: fileName) else {
+            throw ServerExtrasError.invalidFilename
+        }
+        
+        self.name = String(fileName[nameRange])
+        self.location = url
+    }
+}
+
+
+extension ServerExtras {
+    enum ServerExtrasError: Error {
+        case invalidArchive(URL)
+        case invalidFilename
+    }
+}
+
+extension ServerExtras.ServerExtrasError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidArchive(let url): return "Unable to access extras archive at '\(url.path)'"
+        case .invalidFilename: return "Unable to get server name from archive file name"
+        }
+    }
+}

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -133,8 +133,8 @@ final class BackupService {
     }
 
     private func validateServerFolders() throws {
-        let bedrockWorlds = config.containers?.bedrock?.flatMap({ $0.worlds }) ?? []
-        let javaWorlds = config.containers?.java?.flatMap({ $0.worlds }) ?? []
+        let bedrockWorlds = config.containers?.bedrock?.flatMap({ $0.worlds + ($0.extras ?? []) }) ?? []
+        let javaWorlds = config.containers?.java?.flatMap({ $0.worlds + ($0.extras ?? []) }) ?? []
         let oldWorlds = config.servers?.values.map({ $0 }) ?? []
 
         let allWorlds: [String] = bedrockWorlds + javaWorlds + oldWorlds
@@ -384,9 +384,9 @@ extension BackupService.ServiceError: LocalizedError {
             return "No valid backup interval was able to be read from configuration or environment"
         case .onlyOneIntervalTypeAllowed:
             return "Only one of `interval` and `daily` are allowed"
-        case .worldFoldersNotFound(let worlds):
-            let worldsString = worlds.joined(separator: ", ")
-            return "One or more worlds weren't found: \(worldsString)"
+        case .worldFoldersNotFound(let folders):
+            let foldersString = folders.joined(separator: ", ")
+            return "One or more folders weren't found: \(foldersString)"
         case .unableToMarkHealthy:
             return "Unable to write to backups folder"
         }

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -311,16 +311,23 @@ final class BackupService {
     private func runPostBackupTasks() throws {
         if let ownershipConfig = config.ownership {
             BackupService.logger.info("Performing Ownership Fixup")
-            try WorldBackup.fixOwnership(at: backupUrl, config: ownershipConfig)
+            try Backups.fixOwnership(at: backupUrl, config: ownershipConfig)
         }
 
         if let trimJob = config.trim {
             BackupService.logger.info("Performing Trim Jobs")
-            try WorldBackup.trimBackups(at: backupUrl,
-                                        dryRun: false,
-                                        trimDays: trimJob.trimDays,
-                                        keepDays: trimJob.keepDays,
-                                        minKeep: trimJob.minKeep)
+            try Backups.trimBackups(World.self,
+                                    at: backupUrl,
+                                    dryRun: false,
+                                    trimDays: trimJob.trimDays,
+                                    keepDays: trimJob.keepDays,
+                                    minKeep: trimJob.minKeep)
+            try Backups.trimBackups(ServerExtras.self,
+                                    at: backupUrl,
+                                    dryRun: false,
+                                    trimDays: trimJob.trimDays,
+                                    keepDays: trimJob.keepDays,
+                                    minKeep: trimJob.minKeep)
         }
     }
 

--- a/Tests/BedrockifierTests/ServerExtrasTests.swift
+++ b/Tests/BedrockifierTests/ServerExtrasTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Bedrockifier
+
+final class ServerExtrasTests: XCTestCase {
+    func testInvalidUrl() {
+        let testPath = "/backups/Yosemite.Timestamp.zip"
+        let testUrl = URL(fileURLWithPath: testPath)
+
+        do {
+            let _ = try ServerExtras(url: testUrl)
+            XCTFail("Expected the call to throw")
+        } catch ServerExtras.ServerExtrasError.invalidArchive(let url) {
+            XCTAssertEqual(url, testUrl)
+        } catch let error {
+            XCTFail("\(error.localizedDescription)")
+        }
+    }
+
+    func testValidUrl() {
+        let testPath = "/backups/minecraft_cascades.extras.Timestamp.zip"
+        let testUrl = URL(fileURLWithPath: testPath)
+
+        do {
+            let extras = try ServerExtras(url: testUrl)
+
+            XCTAssertEqual(extras.name, "minecraft_cascades")
+            XCTAssertEqual(extras.location, testUrl)
+        } catch ServerExtras.ServerExtrasError.invalidArchive(let url) {
+            XCTFail("Expected this url to not throw: \(url.path)")
+        } catch let error {
+            XCTFail("\(error.localizedDescription)")
+        }
+    }
+}


### PR DESCRIPTION
This adds functionality to backup extra folders from the container into their own extras zip file associated with the container. It includes behaviors to trim 

```
java:
    - name: <container name>
      extras:
        - <folder path>
      worlds:
        - <world path>
```

The result is a series of zip files. So if I have a container called “minecraft_server” and the world was “Yosemite”, the result would be:

minecraft_server.extras.Timestamp.zip
Yosemite.Timestamp.zip