### PR TITLE
Fix Java World Names in Logging

### DIFF
--- a/Sources/Bedrockifier/Model/World.swift
+++ b/Sources/Bedrockifier/Model/World.swift
@@ -121,7 +121,7 @@ public struct World {
             throw WorldError.invalidLevelArchive
         }
 
-        guard let worldName = URL(fileURLWithPath: levelDat.path).pathComponents.first else {
+        guard let worldName = NSString(string: levelDat.path).pathComponents.first else {
             throw WorldError.missingLevelName
         }
 


### PR DESCRIPTION
Fixes a minor issue where Java world names would always show up as "/" in the logs.