### PR TITLE
Fix Error Handling During Startup

### DIFF
--- a/Docker/configure.sh
+++ b/Docker/configure.sh
@@ -8,7 +8,7 @@ swift_base="swift"
 swift_version="5.6.2"
 if [ "$arch" == "arm64" ]; then 
     swift_base="swiftarm/${swift_base}"
-    swift_version="${swift_version}-ubuntu-hirsute"
+    swift_version="${swift_version}-ubuntu-jammy"
 fi
 
 GITHUB_ENV=${GITHUB_ENV:-}

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -80,7 +80,7 @@ struct Server: ParsableCommand {
 
         updateLoggingLevel(config: config, environment: environment)
 
-        Server.logger.info("Configuration Loaded, Entering Event Loop...")
+        Server.logger.info("Configuration Loaded, Running Service...")
         do {
             let service = BackupService(config: config, backupUrl: backupUrl, dockerPath: dockerPath)
 


### PR DESCRIPTION
When doing work based on Swift Concurrency, errors that are thrown during startup don't actually get reported properly to the user, and we don't fail startup so the service hangs. 

- Exit if we catch a thrown error during startup.
- Report the thrown error that is found during startup.