### PR TITLE
Close the Archive before Moving It

### DIFF
--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -131,8 +131,9 @@ public class ContainerConnection {
                 let backupWorld = try world.backup(to: destination)
                 Library.log.info("Backed up as: \(backupWorld.location.lastPathComponent)")
             } catch let error {
-                Library.log.error("\(error.localizedDescription)")
                 Library.log.error("Backup of world at \(worldUrl.path) failed.")
+                Library.log.error("Error: \(error.localizedDescription)")
+                Library.log.debug("Error Details: \(error)")
                 failedBackups.append(worldUrl.path)
             }
         }

--- a/Sources/Bedrockifier/Model/World.swift
+++ b/Sources/Bedrockifier/Model/World.swift
@@ -161,7 +161,12 @@ extension World {
         }
 
         // With it packed successfully, rename it.
-        try FileManager.default.moveItem(at: tempUrl, to: url)
+        do {
+            try FileManager.default.moveItem(at: tempUrl, to: url)
+        } catch let error {
+            Library.log.error("Failed to move \(tempUrl.path) to \(url.path)")
+            throw error
+        }
 
         return try World(url: url)
     }

--- a/Sources/Bedrockifier/Utilities/ScopedObject.swift
+++ b/Sources/Bedrockifier/Utilities/ScopedObject.swift
@@ -1,0 +1,49 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021-2022 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+
+struct NullScopedObjectError: Error {}
+
+func with<T>(scopedObject factory: @autoclosure () -> T, perform: (inout T) -> ()) {
+    var scopedObject = factory()
+    perform(&scopedObject)
+}
+
+func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) -> ()) throws {
+    guard var scopedObject = factory() else {
+        throw NullScopedObjectError()
+    }
+
+    perform(&scopedObject)
+}
+
+func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) throws -> ()) throws {
+    guard var scopedObject = factory() else {
+        throw NullScopedObjectError()
+    }
+
+    try perform(&scopedObject)
+}

--- a/Tests/BedrockifierTests/ScopedObjectTests.swift
+++ b/Tests/BedrockifierTests/ScopedObjectTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import Bedrockifier
+
+final class MockScopedObject {
+    private let deinitHandler: () -> ()
+
+    init(deinitHandler: @escaping () -> ()) {
+        self.deinitHandler = deinitHandler
+    }
+
+    static func makeOptional(succeed: Bool, deinitHandler: @escaping () -> ()) -> MockScopedObject? {
+        if succeed {
+            return MockScopedObject(deinitHandler: deinitHandler)
+        }
+
+        return nil
+    }
+
+    func doSomething() { print("MockScopedObject Did The Thing") }
+
+    deinit {
+        self.deinitHandler()
+    }
+}
+
+struct MockScopedObjectError: Error {}
+
+final class ScopedObjectTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testScopedObject() throws {
+        var didDeinit = false
+        with(scopedObject: MockScopedObject(deinitHandler: { didDeinit = true }) ) { scopedObject in
+            scopedObject.doSomething()
+            XCTAssertFalse(didDeinit)
+        }
+        XCTAssertTrue(didDeinit)
+    }
+
+    func testTryScopedObject_Success() throws {
+        var didDeinit = false
+        try with(scopedOptional: MockScopedObject.makeOptional(succeed: true, deinitHandler: { didDeinit = true }) ) { scopedObject in
+            scopedObject.doSomething()
+            XCTAssertFalse(didDeinit)
+        }
+        XCTAssertTrue(didDeinit)
+    }
+
+    func testTryScopedObject_Failure() throws {
+        do {
+            try with(scopedOptional: MockScopedObject.makeOptional(succeed: false, deinitHandler: {})) { scopedObject in
+                XCTFail("Should not be able to act on anything")
+            }
+            XCTFail("Should have thrown here")
+        } catch is NullScopedObjectError {
+        } catch {
+            XCTFail("Wrong Error Thrown")
+        }
+    }
+
+    func testThrowingScope() throws {
+        var didDeinit = false
+        do {
+            try with(scopedOptional: MockScopedObject.makeOptional(succeed: true, deinitHandler: { didDeinit = true }) ) { scopedObject in
+                XCTAssertFalse(didDeinit)
+                throw MockScopedObjectError()
+            }
+        } catch is NullScopedObjectError {
+            XCTFail("Wrong Error Thrown")
+        } catch {}
+        XCTAssertTrue(didDeinit)
+    }
+}


### PR DESCRIPTION
This makes it so that the Archive itself is scoped to just when we want to pack files into it. Once it leaves the scope, it will deinit and close. Also added some useful logging for getting more details from errors (with debug/trace level logging on), and explicitly log an error when the archive can't be moved.