### PR TITLE
Allow rcon-cli for Java Servers

### DIFF
--- a/Sources/Bedrockifier/Commands/BackupJobCommand.swift
+++ b/Sources/Bedrockifier/Commands/BackupJobCommand.swift
@@ -106,7 +106,9 @@ public final class BackupJobCommand: Command {
                 Library.log.info("Performing Backups")
                 for container in containers {
                     try container.start()
+                    try container.startRcon()
                     try await container.runBackup(destination: backupUrl)
+                    await container.stopRcon()
                     await container.stop()
                 }
 

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -42,6 +42,7 @@ public struct BackupConfig: Codable {
 
     public struct ContainerConfig: Codable {
         public var name: String
+        public var useRcon: Bool?
         public var extras: [String]?
         public var worlds: [String]
     }

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -64,6 +64,7 @@ public class ContainerConnection {
         self.playerCount = 0
         self.lastBackup = .distantPast
 
+        try self.terminal.setWindowSize(columns: 65000, rows: 24)
         self.rconTerminal = kind == .javaWithRcon ? try PseudoTerminal() : nil
 
         let processUrl = ContainerConnection.getPtyProcess(dockerPath: dockerPath)

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -292,6 +292,12 @@ public class ContainerConnection {
     }
 
     private func pauseSaveOnJava() async throws {
+        if kind == .javaWithRcon {
+            if try await expect([">"], timeout: 30.0) == .noMatch {
+                throw ContainerError.pauseFailed
+            }
+        }
+
         // Need a longer timeout on the flush in case server is still starting up
         try controlTerminal.sendLine("save-all flush")
         if try await expect(["Saved the game"], timeout: 30.0) == .noMatch {

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -83,8 +83,9 @@ public class ContainerConnection {
     }
 
     public func start() throws {
-        Library.log.debug("Starting Container Process. (container: \(name))")
+        Library.log.debug("Starting Docker Process. (container: \(name))")
         try dockerProcess.run()
+        logTerminalSize()
     }
 
     public func stop() async {
@@ -372,6 +373,15 @@ public class ContainerConnection {
 
     private func holdFile(destination: URL) -> URL {
         destination.appendingPathComponent(".\(self.name).hold")
+    }
+
+    private func logTerminalSize() {
+        do {
+            let windowSize = try terminal.getWindowSize()
+            Library.log.debug("Docker Process Window Size Fetched. (cols = \(windowSize.ws_col), rows = \(windowSize.ws_row)")
+        } catch {
+            Library.log.debug("Failed to get terminal window size")
+        }
     }
 
     private static func getPtyArguments(dockerPath: String, containerName: String) -> [String] {

--- a/Sources/Service/BackupActor.swift
+++ b/Sources/Service/BackupActor.swift
@@ -136,7 +136,9 @@ actor BackupActor {
 
         BackupService.logger.info("Running Single Backup for \(container.name)")
         do {
+            try container.startRcon()
             try await container.runBackup(destination: backupUrl)
+            await container.stopRcon()
             try runPostBackupTasks()
             BackupService.logger.info("Single Backup Completed")
             _ = markHealthy()

--- a/Sources/Service/BackupActor.swift
+++ b/Sources/Service/BackupActor.swift
@@ -81,8 +81,10 @@ actor BackupActor {
                             try container.start()
                         }
 
-                        BackupService.logger.info("Resuming autosave on \(container.name)")
+                        BackupService.logger.info("Cleaning up old backups for \(container.name)")
+                        try container.startRcon()
                         try await container.cleanupIncompleteBackup(destination: backupUrl)
+                        await container.stopRcon()
 
                         if !wasRunning {
                             await container.stop()
@@ -173,7 +175,11 @@ actor BackupActor {
                 if !needsListeners {
                     try container.start()
                 }
+
+                try container.startRcon()
                 try await container.runBackup(destination: backupUrl)
+                await container.stopRcon()
+
                 if !needsListeners {
                     await container.stop()
                 }

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -26,4 +26,3 @@ docker build . -f Docker/Dockerfile \
     -t $dockerTag \
     --build-arg arch=${arch} \
 #    --build-arg swift_base=${swift_base} \
-#    --build-arg swift_version=${swift_version}


### PR DESCRIPTION
This enables the ability to use rcon-cli to control Java Servers, which means it is possible to wake up a paused Java server to back it up.

Resolves #60 
Also Resolves #62