### PR TITLE
Support RCON instead of requiring Docker

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,5 +1,9 @@
 ARG swift_image=swift:5.9.2-jammy
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 ###### BUILDER
 FROM $swift_image as builder
 WORKDIR /project
@@ -10,8 +14,6 @@ RUN swift build -c release -Xswiftc -g
 ###### RUNTIME CONTAINER
 FROM $swift_image-slim
 WORKDIR /opt/bedrock
-
-ARG arch
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -24,7 +26,7 @@ HEALTHCHECK --start-period=1m CMD bash /opt/bedrock/healthcheck.sh
 
 ARG GITHUB_BASEURL=https://github.com
 
-ARG EASY_ADD_VERSION=0.8.2
+ARG EASY_ADD_VERSION=0.8.3
 ADD ${GITHUB_BASEURL}/itzg/easy-add/releases/download/${EASY_ADD_VERSION}/easy-add_${TARGETOS}_${TARGETARCH}${TARGETVARIANT} /usr/bin/easy-add
 RUN chmod +x /usr/bin/easy-add
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,9 +1,5 @@
 ARG swift_image=swift:5.9.2-jammy
 
-ARG TARGETOS
-ARG TARGETARCH
-ARG TARGETVARIANT
-
 ###### BUILDER
 FROM $swift_image as builder
 WORKDIR /project
@@ -14,6 +10,10 @@ RUN swift build -c release -Xswiftc -g
 ###### RUNTIME CONTAINER
 FROM $swift_image-slim
 WORKDIR /opt/bedrock
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -22,11 +22,19 @@ RUN apt-get update && \
 ENTRYPOINT ["/usr/local/bin/entrypoint-demoter", "--match", "/backups", "--debug", "--stdin-on-term", "stop", "/opt/bedrock/bedrockifierd"]
 HEALTHCHECK --start-period=1m CMD bash /opt/bedrock/healthcheck.sh
 
-ARG EASY_ADD_VERSION=0.7.0
-ADD https://github.com/itzg/easy-add/releases/download/${EASY_ADD_VERSION}/easy-add_linux_${arch} /usr/local/bin/easy-add
-RUN chmod +x /usr/local/bin/easy-add
+ARG GITHUB_BASEURL=https://github.com
 
-RUN easy-add --var version=0.2.1 --var app=entrypoint-demoter --file {{.app}} --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_linux_${arch}.tar.gz
+ARG EASY_ADD_VERSION=0.8.2
+ADD ${GITHUB_BASEURL}/itzg/easy-add/releases/download/${EASY_ADD_VERSION}/easy-add_${TARGETOS}_${TARGETARCH}${TARGETVARIANT} /usr/bin/easy-add
+RUN chmod +x /usr/bin/easy-add
+
+ARG RCON_CLI_VERSION=1.6.4
+RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
+  --var version=${RCON_CLI_VERSION} --var app=rcon-cli --file {{.app}} \
+  --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
+
+ARG ENTRYPOINT_DEMOTER_VERSION=0.4.2
+RUN easy-add --var version=${ENTRYPOINT_DEMOTER_VERSION} --var app=entrypoint-demoter --file {{.app}} --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/v{{.version}}/{{.app}}_{{.version}}_linux_${TARGETARCH}.tar.gz
 
 COPY --from=builder /project/.build/release/bedrockifier-tool .
 COPY --from=builder /project/.build/release/bedrockifierd .

--- a/Docker/merge.sh
+++ b/Docker/merge.sh
@@ -4,9 +4,11 @@
 
 tag=$1
 
+echo Running 'docker buildx imagetools create'
 docker buildx imagetools create \
     -t $tag \
     $tag-amd64 \
     $tag-arm64 \
 
+echo Pushing created tag
 docker push $tag

--- a/Sources/Bedrockifier/Commands/BackupCommand.swift
+++ b/Sources/Bedrockifier/Commands/BackupCommand.swift
@@ -98,7 +98,7 @@ public final class BackupCommand: Command {
                 let worldsPaths = worlds.map({ $0.location.path })
                 let connection = try ContainerConnection(terminalPath: signature.dockerPath,
                                                          containerName: signature.containerName,
-                                                         rconAddress: nil,
+                                                         rcon: nil,
                                                          kind: .bedrock,
                                                          worlds: worldsPaths,
                                                          extras: nil)

--- a/Sources/Bedrockifier/Commands/BackupCommand.swift
+++ b/Sources/Bedrockifier/Commands/BackupCommand.swift
@@ -96,8 +96,9 @@ public final class BackupCommand: Command {
                 let worldsPath = URL(fileURLWithPath: signature.worldsPath)
                 let worlds = try World.getWorlds(at: worldsPath)
                 let worldsPaths = worlds.map({ $0.location.path })
-                let connection = try ContainerConnection(dockerPath: signature.dockerPath,
+                let connection = try ContainerConnection(terminalPath: signature.dockerPath,
                                                          containerName: signature.containerName,
+                                                         rconAddress: nil,
                                                          kind: .bedrock,
                                                          worlds: worldsPaths,
                                                          extras: nil)

--- a/Sources/Bedrockifier/Extensions/StringExtensions.swift
+++ b/Sources/Bedrockifier/Extensions/StringExtensions.swift
@@ -40,6 +40,19 @@ extension String {
 enum ParseError: Error {
     case invalidSyntax
     case outOfBounds
+    case invalidHostname(String)
+}
+
+extension ParseError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .invalidSyntax: "Invalid Syntax"
+        case .outOfBounds: "Out of Bounds"
+        case .invalidHostname(let address): "Invalid Format for Address: \(address)"
+        }
+    }
+
+    var localizedDescripion: String { description }
 }
 
 func parse(ownership: String) throws -> (UInt32?, UInt32?) {

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -43,6 +43,7 @@ public struct BackupConfig: Codable {
     public struct ContainerConfig: Codable {
         public var name: String
         public var rconAddr: String?
+        public var rconPassword: String?
         public var extras: [String]?
         public var worlds: [String]
     }

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -42,7 +42,7 @@ public struct BackupConfig: Codable {
 
     public struct ContainerConfig: Codable {
         public var name: String
-        public var useRcon: Bool?
+        public var rconAddr: String?
         public var extras: [String]?
         public var worlds: [String]
     }
@@ -53,6 +53,7 @@ public struct BackupConfig: Codable {
     }
 
     public var dockerPath: String?
+    public var rconPath: String?
     public var backupPath: String?
     public var servers: ServerConfig?
     public var containers: ServerContainersConfig?

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -74,7 +74,7 @@ public class ContainerConnection {
     }
 
     public convenience init(terminalPath: String, containerName: String, rcon: RconConfig?, kind: Kind, worlds: [String], extras: [String]?) throws {
-        let terminal = try PseudoTerminal()
+        let terminal = try PseudoTerminal(identifier: containerName)
         try self.init(terminal: terminal,
                       terminalPath: terminalPath,
                       containerName: containerName,
@@ -391,6 +391,7 @@ extension ContainerConnection {
     public static func loadContainers(from config: BackupConfig, dockerPath: String, rconPath: String) throws -> [ContainerConnection] {
         var containers: [ContainerConnection] = []
         for container in config.containers?.bedrock ?? [] {
+            Library.log.debug("Creating Bedrock Container Connection. (container: \(container.name))")
             let processPath = container.rconAddr == nil ? dockerPath : rconPath
             let rconConfig = rconConfig(address: container.rconAddr, password: container.rconPassword)
             let connection = try ContainerConnection(terminalPath: processPath,
@@ -403,6 +404,7 @@ extension ContainerConnection {
         }
 
         for container in config.containers?.java ?? [] {
+            Library.log.debug("Creating Java Container Connection. (container: \(container.name)")
             let processPath = container.rconAddr == nil ? dockerPath : rconPath
             let rconConfig = rconConfig(address: container.rconAddr, password: container.rconPassword)
             let connection = try ContainerConnection(terminalPath: processPath,

--- a/Sources/Service/BackupActor.swift
+++ b/Sources/Service/BackupActor.swift
@@ -82,9 +82,7 @@ actor BackupActor {
                         }
 
                         BackupService.logger.info("Cleaning up old backups for \(container.name)")
-                        try container.startRcon()
                         try await container.cleanupIncompleteBackup(destination: backupUrl)
-                        await container.stopRcon()
 
                         if !wasRunning {
                             await container.stop()
@@ -136,9 +134,7 @@ actor BackupActor {
 
         BackupService.logger.info("Running Single Backup for \(container.name)")
         do {
-            try container.startRcon()
             try await container.runBackup(destination: backupUrl)
-            await container.stopRcon()
             try runPostBackupTasks()
             BackupService.logger.info("Single Backup Completed")
             _ = markHealthy()
@@ -178,9 +174,7 @@ actor BackupActor {
                     try container.start()
                 }
 
-                try container.startRcon()
                 try await container.runBackup(destination: backupUrl)
-                await container.stopRcon()
 
                 if !needsListeners {
                     await container.stop()

--- a/Sources/Service/EnvironmentConfig.swift
+++ b/Sources/Service/EnvironmentConfig.swift
@@ -33,11 +33,13 @@ struct EnvironmentConfig {
     let dataDirectory: String
     let configFile: String
     let dockerPath: String
+    let rconPath: String
 
     init() {
         self.backupInterval = ProcessInfo.processInfo.environment["BACKUP_INTERVAL"]
         self.dataDirectory = ProcessInfo.processInfo.environment["DATA_DIR"] ?? "/backups"
         self.configFile = ProcessInfo.processInfo.environment["CONFIG_FILE"] ?? "config.yml"
         self.dockerPath = ProcessInfo.processInfo.environment["DOCKER_PATH"] ?? "/usr/bin/docker"
+        self.rconPath = ProcessInfo.processInfo.environment["RCON_PATH"] ?? "/usr/local/bin/rcon-cli"
     }
 }

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -48,15 +48,17 @@ final class BackupService {
     let environment: EnvironmentConfig
     let backupUrl: URL
     let dockerPath: String
+    let rconPath: String
     let backupActor: BackupActor
 
     var intervalTimer: ServiceTimer<String>?
 
-    init(config: BackupConfig, backupUrl: URL, dockerPath: String) {
+    init(config: BackupConfig, backupUrl: URL, dockerPath: String, rconPath: String) {
         self.config = config
         self.environment = EnvironmentConfig()
         self.backupUrl = backupUrl
         self.dockerPath = dockerPath
+        self.rconPath = rconPath
         self.backupActor = BackupActor(config: config, destination: backupUrl)
     }
 
@@ -112,7 +114,7 @@ final class BackupService {
     }
 
     private func connectContainers() async throws {
-        let containers = try ContainerConnection.loadContainers(from: config, dockerPath: dockerPath)
+        let containers = try ContainerConnection.loadContainers(from: config, dockerPath: dockerPath, rconPath: rconPath)
 
         // Attach to the containers
         if await backupActor.needsListeners() {

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -159,7 +159,7 @@ final class BackupService {
 
         BackupService.logger.info("Backup Interval: \(interval) seconds")
         let timer = ServiceTimer(identifier: "interval", queue: DispatchQueue.main)
-        var startTime = Date()
+        let startTime = Date()
         timer.schedule(startingAt: startTime, repeating: .seconds(Int(interval)))
         timer.setHandler(priority: BackupService.backupPriority) {
             await self.backupActor.backupAllContainers(isDaily: false)

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -40,6 +40,9 @@ struct Server: ParsableCommand {
     @Option(name: .shortAndLong, help: "Path to docker")
     var dockerPath: String?
 
+    @Option(name: .shortAndLong, help: "Path to rcon-cli")
+    var rconPath: String?
+
     @Option(name: .shortAndLong, help: "Folder to write backups to")
     var backupPath: String?
 
@@ -76,13 +79,24 @@ struct Server: ParsableCommand {
             return
         }
 
+        let rconPath = self.rconPath ?? config.rconPath ?? environment.rconPath
+        guard FileManager.default.fileExists(atPath: rconPath) else {
+            Server.logger.error("rcon-cli not found at path \(rconPath)")
+            return
+        }
+
         let backupUrl = URL(fileURLWithPath: backupPath)
 
         updateLoggingLevel(config: config, environment: environment)
 
         Server.logger.info("Configuration Loaded, Running Service...")
         do {
-            let service = BackupService(config: config, backupUrl: backupUrl, dockerPath: dockerPath)
+            let service = BackupService(
+                config: config,
+                backupUrl: backupUrl,
+                dockerPath: dockerPath,
+                rconPath: rconPath
+            )
 
             try service.run()
         } catch let error {

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -10,12 +10,14 @@ PUSH=${3:-nopush}
 dockerRepo=kaiede/minecraft-bedrock-backup
 dockerBaseTag=$dockerRepo:${tag}
 
-arch=`arch`
+TARGETOS='linux'
+TARGETARCH=`arch`
+TARGETVARIANT=''
 if [ "$arch" == "x86_64" ]; then
-    arch=amd64
+    TARGETARCH=amd64
 fi
 if [ "$arch" == "aarch64" ]; then
-    arch=arm64
+    TARGETARCH=arm64
 fi
 
 #. Docker/configure.sh $arch
@@ -24,5 +26,7 @@ dockerTag=$dockerRepo:${tag}-${arch}
 
 docker build . -f Docker/Dockerfile \
     -t $dockerTag \
-    --build-arg arch=${arch} \
+    --build-arg TARGETOS=${TARGETOS} \
+    --build-arg TARGETARCH=${TARGETARCH} \
+    --build-arg TARGETVARIANT="" \
 #    --build-arg swift_base=${swift_base} \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -13,16 +13,16 @@ dockerBaseTag=$dockerRepo:${tag}
 TARGETOS='linux'
 TARGETARCH=`arch`
 TARGETVARIANT=''
-if [ "$arch" == "x86_64" ]; then
+if [ "$TARGETARCH" == "x86_64" ]; then
     TARGETARCH=amd64
 fi
-if [ "$arch" == "aarch64" ]; then
+if [ "$TARGETARCH" == "aarch64" ]; then
     TARGETARCH=arm64
 fi
 
 #. Docker/configure.sh $arch
 
-dockerTag=$dockerRepo:${tag}-${arch}
+dockerTag=$dockerRepo:${tag}-${TARGETARCH}
 
 docker build . -f Docker/Dockerfile \
     -t $dockerTag \


### PR DESCRIPTION
This adds support for using rcon-cli instead of the docker cli to talk to the Minecraft servers for backups:

Good:
- Just need to supply `rconAddr` and `rconPassword` to the backup container config.yml file.
- Docker-compose changes will use `expose` which ensures the rcon port is only accessible to other docker containers in the compose file. 
- If Bedrock servers ever support rcon, or get the console wrapped in an rcon implementation, then this will work for Bedrock as well.

Bad:
- Event based backups (player login or logout) don't work over rcon. Although this could be acceptable seeing as it no longer requires access to docker.sock to work for Java.