### PR TITLE
Integrated SSH Client

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,21 +15,17 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Docker - linux/${{ matrix.arch }}
+    name: Docker - ${{ matrix.os }}
     if: github.repository == 'Kaiede/Bedrockifier'
+    env:
+      ARCH: ${{ matrix.os == 'ubuntu-latest' && 'linux/amd64' || 'linux/arm64' }}
     strategy:
       matrix:
-        arch: [amd64, arm64]
-    
+        os: ['ubuntu-latest', 'buildjet-2vcpu-ubuntu-2204-arm']
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@master
-      if: matrix.arch != 'amd64'
-      with:
-        platforms: arm64
 
     - name: Set up Docker Buildx
       id: buildx
@@ -48,7 +44,7 @@ jobs:
         builder: ${{ steps.buildx.outputs.name }}
         context: .
         file: ./Docker/Dockerfile
-        platforms: linux/${{ matrix.arch }}
+        platforms: ${{ env.ARCH }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: kaiede/minecraft-bedrock-backup:${{ env.docker_tag }}-${{ matrix.arch }}
         build-args: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,13 +33,13 @@ jobs:
 
     - name: Login to DockerHub
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3.1.0
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build ${{ matrix.arch }}
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5.3.0
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: .
@@ -60,7 +60,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.3
 
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
       id: buildx
@@ -33,13 +33,13 @@ jobs:
 
     - name: Login to DockerHub
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v3.1.0
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build ${{ matrix.arch }}
-      uses: docker/build-push-action@v5.3.0
+      uses: docker/build-push-action@v5
       with:
         builder: ${{ steps.buildx.outputs.name }}
         context: .
@@ -60,7 +60,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.3
+      uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
       id: buildx
@@ -68,7 +68,7 @@ jobs:
 
     - name: Login to DockerHub
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -18,8 +18,6 @@ ARG TARGETVARIANT
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
     docker.io \
-    openssh-client \
-    sshpass \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Docker/entry.sh
+++ b/Docker/entry.sh
@@ -4,12 +4,5 @@
 #
 # Used by the docker container
 
-
-# Configure User for SSH
-uid=$(stat -c %u /backups)
-deluser bedrockifier
-[ -x /usr/sbin/useradd ] && useradd -m -u ${uid} bedrockifier -s /bin/sh || adduser --disabled-login --uid ${uid} bedrockifier --shell /bin/sh;
-export HOME=/backups
-
 # Execute
 /usr/local/bin/entrypoint-demoter --match /backups --debug --stdin-on-term stop /opt/bedrock/bedrockifierd

--- a/Package.swift
+++ b/Package.swift
@@ -22,13 +22,14 @@ let package = Package(
         ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/vapor/console-kit.git", .upToNextMinor(from: "4.2.5")),
-        .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0")),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.3"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssh.git", from: "0.8.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
+        .package(url: "https://github.com/Kaiede/PTYKit.git", branch: "master"),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.3"),
-        .package(url: "https://github.com/Kaiede/PTYKit.git", branch: "master")
+        .package(url: "https://github.com/vapor/console-kit.git", .upToNextMinor(from: "4.2.5")),
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -53,6 +54,7 @@ let package = Package(
             name: "Bedrockifier",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOSSH", package: "swift-nio-ssh"),
                 .product(name: "PTYKit", package: "PTYKit"),
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation")

--- a/Sources/Bedrockifier/Client/SSHClient.swift
+++ b/Sources/Bedrockifier/Client/SSHClient.swift
@@ -63,6 +63,7 @@ final class SSHClient {
     func close() async throws {
         Library.log.trace("Closing SSH connection.")
         try await connectedChannel?.close()
+        self.connectedChannel = nil
     }
 
     private func makeBootstrap() -> ClientBootstrap {

--- a/Sources/Bedrockifier/Client/SSHClient.swift
+++ b/Sources/Bedrockifier/Client/SSHClient.swift
@@ -1,0 +1,142 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+
+import Foundation
+
+import NIOCore
+import NIOPosix
+import NIOSSH
+import PTYKit
+
+final class SSHClient {
+    private let group: EventLoopGroup
+    private let terminal: PseudoTerminal
+    private let userAuthDelegate: NIOSSHClientUserAuthenticationDelegate
+    private let serverAuthDelegate: NIOSSHClientServerAuthenticationDelegate
+
+    private var connectedChannel: Channel?
+
+    init(group: EventLoopGroup, terminal: PseudoTerminal, password: String) {
+        self.group = group
+        self.terminal = terminal
+        self.userAuthDelegate = SSHBasicAuthDelegate(password: password)
+        self.serverAuthDelegate = SSHAcceptKnownHostKeysDelegate()
+    }
+
+    func connect(host: String, port: Int) async throws {
+        let bootstrap = makeBootstrap()
+        let channel = try await bootstrap.connect(host: host, port: port).get()
+
+        self.connectedChannel = try await channel.pipeline.handler(type: NIOSSHHandler.self).flatMap { [self] handler in
+            return makeChildHandler(eventLoop: channel.eventLoop, handler: handler)
+        }.get()
+    }
+
+    var isConnected: Bool {
+        return connectedChannel != nil
+    }
+
+    func close() async throws {
+        try await connectedChannel?.close()
+    }
+
+    private func makeBootstrap() -> ClientBootstrap {
+        return ClientBootstrap(group: group)
+            .channelInitializer(self.initializeChannel)
+            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
+    }
+
+    private func initializeChannel(channel: Channel) -> EventLoopFuture<Void> {
+        channel.pipeline.addHandlers([
+            NIOSSHHandler(
+                role: .client(.init(
+                    userAuthDelegate: self.userAuthDelegate,
+                    serverAuthDelegate: self.serverAuthDelegate
+                )),
+                allocator: channel.allocator,
+                inboundChildChannelInitializer: nil),
+            SSHErrorHandler()
+        ])
+    }
+
+    private func makeChildHandler(eventLoop: EventLoop, handler: NIOSSHHandler) -> EventLoopFuture<Channel> {
+        let promise = eventLoop.makePromise(of: Channel.self)
+        handler.createChannel(promise) { child, channelType in
+            guard channelType == .session else {
+                return eventLoop.makeFailedFuture(SSHClientError.unsupportedChannelType)
+            }
+
+            return child.pipeline.addHandlers([
+                SSHPipeHandler(),
+                TerminalHandler(terminal: self.terminal),
+                SSHErrorHandler()
+            ])
+        }
+
+        return promise.futureResult
+    }
+}
+
+final class SSHAcceptKnownHostKeysDelegate: NIOSSHClientServerAuthenticationDelegate {
+    func validateHostKey(hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>) {
+        // TODO: We should record keys and throw errors if those keys change.
+        validationCompletePromise.succeed()
+    }
+}
+
+
+final class SSHBasicAuthDelegate: NIOSSHClientUserAuthenticationDelegate {
+    private let username = "bedrockifier"
+    private let password: String
+
+    init(password: String) {
+        self.password = password
+    }
+
+    func nextAuthenticationType(
+        availableMethods: NIOSSH.NIOSSHAvailableUserAuthenticationMethods,
+        nextChallengePromise: NIOCore.EventLoopPromise<NIOSSH.NIOSSHUserAuthenticationOffer?>
+    ) {
+        guard availableMethods.contains(.password) else {
+            nextChallengePromise.fail(SSHClientError.passwordAuthenticationNotSupported)
+            return
+        }
+
+        nextChallengePromise.succeed(
+            NIOSSHUserAuthenticationOffer(
+                username: self.username,
+                serviceName: "",
+                offer: .password(.init(password: self.password)))
+        )
+
+    }
+}
+
+enum SSHClientError: Error {
+    case passwordAuthenticationNotSupported
+    case unsupportedChannelType
+}

--- a/Sources/Bedrockifier/Client/SSHClient.swift
+++ b/Sources/Bedrockifier/Client/SSHClient.swift
@@ -104,6 +104,7 @@ final class SSHClient {
 final class SSHAcceptKnownHostKeysDelegate: NIOSSHClientServerAuthenticationDelegate {
     func validateHostKey(hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>) {
         // TODO: We should record keys and throw errors if those keys change.
+        Library.log.trace("Accepting host key (always).")
         validationCompletePromise.succeed()
     }
 }
@@ -122,6 +123,7 @@ final class SSHBasicAuthDelegate: NIOSSHClientUserAuthenticationDelegate {
         nextChallengePromise: NIOCore.EventLoopPromise<NIOSSH.NIOSSHUserAuthenticationOffer?>
     ) {
         guard availableMethods.contains(.password) else {
+            Library.log.error("SSH authentication failure. Password not supported by server.")
             nextChallengePromise.fail(SSHClientError.passwordAuthenticationNotSupported)
             return
         }

--- a/Sources/Bedrockifier/Client/SSHClient.swift
+++ b/Sources/Bedrockifier/Client/SSHClient.swift
@@ -47,6 +47,7 @@ final class SSHClient {
     }
 
     func connect(host: String, port: Int) async throws {
+        Library.log.info("Connecting to \(host):\(port)")
         let bootstrap = makeBootstrap()
         let channel = try await bootstrap.connect(host: host, port: port).get()
 
@@ -60,6 +61,7 @@ final class SSHClient {
     }
 
     func close() async throws {
+        Library.log.trace("Closing SSH connection.")
         try await connectedChannel?.close()
     }
 

--- a/Sources/Bedrockifier/Client/SSHClient.swift
+++ b/Sources/Bedrockifier/Client/SSHClient.swift
@@ -23,7 +23,6 @@
  SOFTWARE.)
  */
 
-
 import Foundation
 
 import NIOCore
@@ -138,7 +137,7 @@ final class SSHAcceptKnownHostKeysDelegate: NIOSSHClientServerAuthenticationDele
             do {
                 let result = try await validator.validate(hostIdent: hostIdent, publicKey: hostKey)
                 switch result {
-                case .ok:
+                case .keyOk:
                     Library.log.debug("Accepting host key, matches existing host key.")
                     validationCompletePromise.succeed()
                     return
@@ -162,7 +161,6 @@ final class SSHAcceptKnownHostKeysDelegate: NIOSSHClientServerAuthenticationDele
         "\(host):\(port)"
     }
 }
-
 
 final class SSHBasicAuthDelegate: NIOSSHClientUserAuthenticationDelegate {
     private let username = "bedrockifier"

--- a/Sources/Bedrockifier/Client/SSHHandler.swift
+++ b/Sources/Bedrockifier/Client/SSHHandler.swift
@@ -75,7 +75,7 @@ final class SSHErrorHandler: ChannelInboundHandler {
     typealias InboundIn = Any
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-        Library.log.error("Error from SSH pipeline: \(error)")
+        Library.log.error("Error from SSH pipeline: \(error.localizedDescription)")
         context.close(promise: nil)
     }
 }

--- a/Sources/Bedrockifier/Client/SSHHandler.swift
+++ b/Sources/Bedrockifier/Client/SSHHandler.swift
@@ -67,7 +67,7 @@ final class SSHPipeHandler: ChannelDuplexHandler {
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let bytes = self.unwrapOutboundIn(data)
 
-        Library.log.trace("writing data")
+        Library.log.trace("writing data: '\(String(buffer: bytes).withEscapedInvisibles())'")
         let channelData = SSHChannelData(type: .channel, data: .byteBuffer(bytes))
         context.write(self.wrapOutboundOut(channelData), promise: promise)
     }

--- a/Sources/Bedrockifier/Client/SSHHandler.swift
+++ b/Sources/Bedrockifier/Client/SSHHandler.swift
@@ -46,6 +46,7 @@ final class SSHPipeHandler: ChannelDuplexHandler {
         context.triggerUserOutboundEvent(shellRequest).whenComplete { result in
             switch result {
             case .success(_):
+                Library.log.trace("Shell Request Accepted")
                 return
             case .failure(let error):
                 context.fireErrorCaught(error)

--- a/Sources/Bedrockifier/Client/SSHHandler.swift
+++ b/Sources/Bedrockifier/Client/SSHHandler.swift
@@ -23,11 +23,9 @@
  SOFTWARE.)
  */
 
-
 import Foundation
 import NIOCore
 import NIOSSH
-
 
 final class SSHPipeHandler: ChannelDuplexHandler {
     typealias InboundIn = SSHChannelData
@@ -45,7 +43,7 @@ final class SSHPipeHandler: ChannelDuplexHandler {
         let shellRequest = SSHChannelRequestEvent.ShellRequest(wantReply: false)
         context.triggerUserOutboundEvent(shellRequest).whenComplete { result in
             switch result {
-            case .success(_):
+            case .success:
                 Library.log.trace("Shell Request Accepted")
                 return
             case .failure(let error):

--- a/Sources/Bedrockifier/Client/SSHHandler.swift
+++ b/Sources/Bedrockifier/Client/SSHHandler.swift
@@ -1,0 +1,81 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+
+import Foundation
+import NIOCore
+import NIOSSH
+
+
+final class SSHPipeHandler: ChannelDuplexHandler {
+    typealias InboundIn = SSHChannelData
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = SSHChannelData
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        context.channel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).whenFailure { error in
+            context.fireErrorCaught(error)
+        }
+    }
+
+    func channelActive(context: ChannelHandlerContext) {
+        let shellRequest = SSHChannelRequestEvent.ShellRequest(wantReply: false)
+        context.triggerUserOutboundEvent(shellRequest).whenComplete { result in
+            switch result {
+            case .success(_):
+                return
+            case .failure(let error):
+                context.fireErrorCaught(error)
+            }
+        }
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let data = self.unwrapInboundIn(data)
+
+        guard case .byteBuffer(let bytes) = data.data else {
+            fatalError("Unexpected typing...")
+        }
+
+        context.fireChannelRead(self.wrapInboundOut(bytes))
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let bytes = self.unwrapOutboundIn(data)
+
+        let channelData = SSHChannelData(type: .channel, data: .byteBuffer(bytes))
+        context.write(self.wrapOutboundOut(channelData), promise: promise)
+    }
+}
+
+final class SSHErrorHandler: ChannelInboundHandler {
+    typealias InboundIn = Any
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        Library.log.error("Error from SSH pipeline: \(error)")
+        context.close(promise: nil)
+    }
+}

--- a/Sources/Bedrockifier/Client/SSHHandler.swift
+++ b/Sources/Bedrockifier/Client/SSHHandler.swift
@@ -60,12 +60,14 @@ final class SSHPipeHandler: ChannelDuplexHandler {
             fatalError("Unexpected typing...")
         }
 
+        Library.log.trace("reading data")
         context.fireChannelRead(self.wrapInboundOut(bytes))
     }
 
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let bytes = self.unwrapOutboundIn(data)
 
+        Library.log.trace("writing data")
         let channelData = SSHChannelData(type: .channel, data: .byteBuffer(bytes))
         context.write(self.wrapOutboundOut(channelData), promise: promise)
     }

--- a/Sources/Bedrockifier/Client/SSHHostKeys.swift
+++ b/Sources/Bedrockifier/Client/SSHHostKeys.swift
@@ -89,7 +89,7 @@ public actor SSHHostKeyValidator {
             lines.append("\(hostIdentifier) \(keyValue)")
         }
 
-        let fileContentStr = lines.joined(separator: "\n")
+        let fileContentStr = lines.joined(separator: "\n").appending("\n")
         guard let fileContentData = fileContentStr.data(using: .utf8) else {
             throw ValidatorError.dataCannotBeConverted
         }

--- a/Sources/Bedrockifier/Client/SSHHostKeys.swift
+++ b/Sources/Bedrockifier/Client/SSHHostKeys.swift
@@ -1,0 +1,99 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+import NIOSSH
+
+public actor SSHHostKeyValidator {
+    enum Result {
+        case ok
+        case notFound
+        case changed
+    }
+
+    enum ValidatorError: Error {
+        case dataCannotBeConverted
+    }
+
+    private let keysFile: URL
+
+    public init(keysFile: URL) {
+        self.keysFile = keysFile
+    }
+
+    func validate(hostIdent: String, publicKey: NIOSSHPublicKey) throws -> Result {
+        let keys = loadKeys()
+        guard let publicKeyStr = keys[hostIdent] else { return .notFound }
+
+        let knownKey = try NIOSSHPublicKey(openSSHPublicKey: publicKeyStr)
+        if knownKey != publicKey {
+            return .changed
+        }
+
+        return .ok
+    }
+
+    func recordKey(hostIdent: String, publicKey: NIOSSHPublicKey) throws {
+        var keys = loadKeys()
+
+        keys[hostIdent] = String(openSSHPublicKey: publicKey)
+        try writeKeys(keys)
+    }
+
+    private func loadKeys() -> [String:String] {
+        do {
+            let keyData = try Data(contentsOf: self.keysFile)
+            guard let keyString = String(data: keyData, encoding: .utf8) else {
+                return [:]
+            }
+
+            var result: [String:String] = [:]
+            let lines = keyString.components(separatedBy: .newlines)
+            for line in lines {
+                let parts = line.split(maxSplits: 1, whereSeparator: { $0.isWhitespace })
+                guard parts.count == 2 else { continue }
+                result[String(parts[0])] = String(parts[1])
+            }
+
+            return result
+        } catch {
+            return [:]
+        }
+    }
+
+    private func writeKeys(_ keys: [String:String]) throws {
+        var lines: [String] = []
+        for (hostIdentifier, keyValue) in keys.enumerated() {
+            lines.append("\(hostIdentifier) \(keyValue)")
+        }
+
+        let fileContentStr = lines.joined(separator: "\n")
+        guard let fileContentData = fileContentStr.data(using: .utf8) else {
+            throw ValidatorError.dataCannotBeConverted
+        }
+
+        try fileContentData.write(to: self.keysFile)
+    }
+}

--- a/Sources/Bedrockifier/Client/SSHHostKeys.swift
+++ b/Sources/Bedrockifier/Client/SSHHostKeys.swift
@@ -28,7 +28,7 @@ import NIOSSH
 
 public actor SSHHostKeyValidator {
     enum Result {
-        case ok
+        case keyOk
         case notFound
         case changed
     }
@@ -52,7 +52,7 @@ public actor SSHHostKeyValidator {
             return .changed
         }
 
-        return .ok
+        return .keyOk
     }
 
     func recordKey(hostIdent: String, publicKey: NIOSSHPublicKey) throws {
@@ -62,14 +62,14 @@ public actor SSHHostKeyValidator {
         try writeKeys(keys)
     }
 
-    private func loadKeys() -> [String:String] {
+    private func loadKeys() -> [String: String] {
         do {
             let keyData = try Data(contentsOf: self.keysFile)
             guard let keyString = String(data: keyData, encoding: .utf8) else {
                 return [:]
             }
 
-            var result: [String:String] = [:]
+            var result: [String: String] = [:]
             let lines = keyString.components(separatedBy: .newlines)
             for line in lines {
                 let parts = line.split(maxSplits: 1, whereSeparator: { $0.isWhitespace })
@@ -83,7 +83,7 @@ public actor SSHHostKeyValidator {
         }
     }
 
-    private func writeKeys(_ keys: [String:String]) throws {
+    private func writeKeys(_ keys: [String: String]) throws {
         var lines: [String] = []
         for (hostIdentifier, keyValue) in keys {
             lines.append("\(hostIdentifier) \(keyValue)")

--- a/Sources/Bedrockifier/Client/SSHHostKeys.swift
+++ b/Sources/Bedrockifier/Client/SSHHostKeys.swift
@@ -85,7 +85,7 @@ public actor SSHHostKeyValidator {
 
     private func writeKeys(_ keys: [String:String]) throws {
         var lines: [String] = []
-        for (hostIdentifier, keyValue) in keys.enumerated() {
+        for (hostIdentifier, keyValue) in keys {
             lines.append("\(hostIdentifier) \(keyValue)")
         }
 

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -23,7 +23,6 @@
  SOFTWARE.)
  */
 
-
 import Foundation
 import NIOCore
 import PTYKit

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -54,7 +54,7 @@ final class TerminalHandler: ChannelDuplexHandler {
             let channel = try terminal.connect()
             channel.fileHandle.readabilityHandler = { handle in
                 let buffer = ByteBuffer(data: handle.availableData)
-                Library.log.trace("read data from terminal \(String(buffer: buffer))")
+                Library.log.trace("read data from terminal \(String(buffer: buffer).withEscapedInvisibles())")
                 context.write(self.wrapOutboundOut(buffer), promise: nil)
             }
 

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -44,6 +44,7 @@ final class TerminalHandler: ChannelDuplexHandler {
     deinit {
         do {
             try terminalChannel?.disconnect()
+            Library.log.info("SSH Terminal disconnected from deinit.")
         } catch {
             Library.log.error("Failed to disconnect from Terminal during deinit. (\(error.localizedDescription)")
         }

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -58,6 +58,7 @@ final class TerminalHandler: ChannelDuplexHandler {
             }
 
             self.terminalChannel = channel
+            Library.log.info("SSH Terminal fully connected.")
         } catch {
             Library.log.error("Failed to connect to terminal. (\(error.localizedDescription))")
         }
@@ -67,6 +68,7 @@ final class TerminalHandler: ChannelDuplexHandler {
         self.terminalChannel?.fileHandle.readabilityHandler = nil
         do {
             try self.terminalChannel?.disconnect()
+            Library.log.info("SSH Terminal disconnected.")
         } catch {
             Library.log.error("Failed to disconnect from Terminal. (\(error.localizedDescription)")
         }

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -53,6 +53,7 @@ final class TerminalHandler: ChannelDuplexHandler {
         do {
             let channel = try terminal.connect()
             channel.fileHandle.readabilityHandler = { handle in
+                Library.log.trace("read data from terminal")
                 let buffer = ByteBuffer(data: handle.availableData)
                 context.write(self.wrapOutboundOut(buffer), promise: nil)
             }
@@ -77,9 +78,11 @@ final class TerminalHandler: ChannelDuplexHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let bytes = unwrapInboundIn(data)
         let writableData = Data(buffer: bytes, byteTransferStrategy: .noCopy)
+        Library.log.trace("writing data to terminal")
         if let terminalChannel = self.terminalChannel {
             do {
                 try terminalChannel.fileHandle.write(contentsOf: writableData)
+                Library.log.trace("written data to terminal")
             } catch {
                 Library.log.error("Failed to write data to terminal fileHandle.")
             }

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -54,8 +54,13 @@ final class TerminalHandler: ChannelDuplexHandler {
         do {
             let channel = try terminal.connect()
             channel.fileHandle.readabilityHandler = { handle in
-                let buffer = ByteBuffer(data: handle.availableData)
-                Library.log.trace("read data from terminal \(String(buffer: buffer).withEscapedInvisibles())")
+                guard var string = String(data: handle.availableData, encoding: .utf8) else {
+                    Library.log.error("Failed to read terminal data as UTF8 for SSH.")
+                    return
+                }
+
+                Library.log.trace("Read data from terminal: '\(string.withEscapedInvisibles())'")
+                let buffer = ByteBuffer(string: string)
                 context.write(self.wrapOutboundOut(buffer), promise: nil)
             }
 

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -53,8 +53,8 @@ final class TerminalHandler: ChannelDuplexHandler {
         do {
             let channel = try terminal.connect()
             channel.fileHandle.readabilityHandler = { handle in
-                Library.log.trace("read data from terminal")
                 let buffer = ByteBuffer(data: handle.availableData)
+                Library.log.trace("read data from terminal \(String(buffer: buffer))")
                 context.write(self.wrapOutboundOut(buffer), promise: nil)
             }
 

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -59,6 +59,7 @@ final class TerminalHandler: ChannelDuplexHandler {
                     return
                 }
 
+                string = string.convertNewlinesForSSH()
                 Library.log.trace("Read data from terminal: '\(string.withEscapedInvisibles())'")
                 let buffer = ByteBuffer(string: string)
                 context.write(self.wrapOutboundOut(buffer), promise: nil)

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -62,7 +62,7 @@ final class TerminalHandler: ChannelDuplexHandler {
                 string = string.convertNewlinesForSSH()
                 Library.log.trace("Read data from terminal: '\(string.withEscapedInvisibles())'")
                 let buffer = ByteBuffer(string: string)
-                context.write(self.wrapOutboundOut(buffer), promise: nil)
+                context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
             }
 
             self.terminalChannel = channel

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -1,0 +1,70 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+
+import Foundation
+import NIOCore
+import PTYKit
+
+final class TerminalHandler: ChannelDuplexHandler {
+    typealias InboundIn = ByteBuffer
+
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    private let terminal: PseudoTerminal
+    private var terminalChannel: PseudoTerminal.Channel?
+
+    init(terminal: PseudoTerminal) {
+        self.terminal = terminal
+    }
+
+    deinit {
+        try? terminalChannel?.disconnect()
+    }
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        if let channel = try? terminal.connect() {
+            channel.fileHandle.readabilityHandler = { handle in
+                let buffer = ByteBuffer(data: handle.availableData)
+                context.write(self.wrapOutboundOut(buffer), promise: nil)
+            }
+        }
+        self.terminalChannel = try? terminal.connect()
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        self.terminalChannel?.fileHandle.readabilityHandler = nil
+        try? self.terminalChannel?.disconnect()
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let bytes = unwrapInboundIn(data)
+        let writableData = Data(buffer: bytes, byteTransferStrategy: .noCopy)
+        if let terminalChannel = self.terminalChannel {
+            try? terminalChannel.fileHandle.write(contentsOf: writableData)
+        }
+    }
+}

--- a/Sources/Bedrockifier/Extensions/StringExtensions.swift
+++ b/Sources/Bedrockifier/Extensions/StringExtensions.swift
@@ -27,10 +27,8 @@ import Foundation
 
 extension String {
     public func contains(oneOf others: [String]) -> Bool {
-        for other in others {
-            if self.contains(other) {
-                return true
-            }
+        for other in others where self.contains(other) {
+            return true
         }
 
         return false

--- a/Sources/Bedrockifier/Foundation/ConsoleLogger.swift
+++ b/Sources/Bedrockifier/Foundation/ConsoleLogger.swift
@@ -96,6 +96,8 @@ public final class ConsoleLogger: LogHandler {
     }
 }
 
+// swiftlint:enable function_parameter_count
+
 private struct LoggingOutputStream: TextOutputStream {
     public static let stdOut = LoggingOutputStream(stdout)
     public static let stdErr = LoggingOutputStream(stderr)

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -69,19 +69,14 @@ public struct BackupConfig: Codable {
 }
 
 extension BackupConfig.ContainerConfig {
-    func readPassword() -> String? {
+    func containerPassword() -> ContainerPassword {
         if let file = passwordFile {
-            let fileUrl = URL(fileURLWithPath: file)
-            if let config = try? RconCliConfig.getYaml(from: fileUrl), let password = config.password {
-                return password
-            } else {
-                Library.log.error("Unable to read the password from the YAML file at: \(file)")
-            }
+            return .passwordFile(URL(fileURLWithPath: file))
         } else if let password = password {
-            return password
+            return .password(password)
         }
 
-        return nil
+        return .none
     }
 }
 

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -1,0 +1,89 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+import NIOPosix
+import PTYKit
+
+protocol ContainerChannel {
+    var isConnected: Bool { get }
+
+    func start() async throws
+    func close() async throws
+    mutating func reset() throws
+}
+
+struct ProcessChannel: ContainerChannel {
+    private let terminal: PseudoTerminal
+    private let processUrl: URL
+    private let processArgs: [String]
+    private var process: Process!
+
+    init(terminal: PseudoTerminal, processUrl: URL, processArgs: [String]) throws {
+        self.terminal = terminal
+        self.processUrl = processUrl
+        self.processArgs = processArgs
+        self.process = try Process(processUrl, arguments: processArgs, terminal: terminal)
+    }
+
+    var isConnected: Bool { process.isRunning }
+
+    func close() {
+        process?.terminate()
+    }
+
+    func start() throws {
+        try self.process?.run()
+    }
+
+    mutating func reset() throws {
+        self.process = try Process(processUrl, arguments: processArgs, terminal: terminal)
+    }
+}
+
+struct SecureShellChannel: ContainerChannel {
+    private let host: String
+    private let port: Int
+    private var client: SSHClient
+
+    init(terminal: PseudoTerminal, host: String, port: Int, password: String) {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        self.client = SSHClient(group: group, terminal: terminal, password: password)
+        self.host = host
+        self.port = port
+    }
+
+    var isConnected: Bool { client.isConnected }
+
+    func start() async throws {
+        try await client.connect(host: host, port: port)
+    }
+
+    func close() async throws {
+        try await client.close()
+    }
+
+    func reset() {}
+}

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -39,7 +39,7 @@ struct ProcessChannel: ContainerChannel {
     private let terminal: PseudoTerminal
     private let processUrl: URL
     private let processArgs: [String]
-    private var process: Process!
+    private var process: Process
 
     init(terminal: PseudoTerminal, processUrl: URL, processArgs: [String]) throws {
         self.terminal = terminal
@@ -51,11 +51,11 @@ struct ProcessChannel: ContainerChannel {
     var isConnected: Bool { process.isRunning }
 
     func close() {
-        process?.terminate()
+        process.terminate()
     }
 
     func start() throws {
-        try self.process?.run()
+        try self.process.run()
     }
 
     mutating func reset() throws {

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -78,11 +78,20 @@ struct SecureShellChannel: ContainerChannel {
     var isConnected: Bool { client.isConnected }
 
     func start() async throws {
-        try await client.connect(host: host, port: port)
+        do {
+            try await client.connect(host: host, port: port)
+        } catch {
+            Library.log.error("Failed to connect SSH channel to host. (\(error.localizedDescription))")
+        }
     }
 
     func close() async throws {
-        try await client.close()
+        do {
+            try await client.close()
+        } catch {
+            Library.log.error("Failed to close SSH channel. (\(error.localizedDescription))")
+            throw error
+        }
     }
 
     func reset() {}

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -68,9 +68,9 @@ struct SecureShellChannel: ContainerChannel {
     private let port: Int
     private var client: SSHClient
 
-    init(terminal: PseudoTerminal, host: String, port: Int, password: String) {
+    init(terminal: PseudoTerminal, host: String, port: Int, validator: SSHHostKeyValidator, password: ContainerPassword) {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        self.client = SSHClient(group: group, terminal: terminal, password: password)
+        self.client = SSHClient(group: group, terminal: terminal, validator: validator, password: password)
         self.host = host
         self.port = port
     }

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -82,6 +82,7 @@ struct SecureShellChannel: ContainerChannel {
             try await client.connect(host: host, port: port)
         } catch {
             Library.log.error("Failed to connect SSH channel to host. (\(error.localizedDescription))")
+            Library.log.error("Check to ensure the SSH configuration is correct, and check the minecraft server logs for further errors.")
         }
     }
 

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -68,7 +68,13 @@ struct SecureShellChannel: ContainerChannel {
     private let port: Int
     private var client: SSHClient
 
-    init(terminal: PseudoTerminal, host: String, port: Int, validator: SSHHostKeyValidator, password: ContainerPassword) {
+    init(
+        terminal: PseudoTerminal,
+        host: String,
+        port: Int,
+        validator: SSHHostKeyValidator,
+        password: ContainerPassword
+    ) {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.client = SSHClient(group: group, terminal: terminal, validator: validator, password: password)
         self.host = host
@@ -82,7 +88,9 @@ struct SecureShellChannel: ContainerChannel {
             try await client.connect(host: host, port: port)
         } catch {
             Library.log.error("Failed to connect SSH channel to host. (\(error.localizedDescription))")
-            Library.log.error("Check to ensure the SSH configuration is correct, and check the minecraft server logs for further errors.")
+            Library.log.error(
+                "Check that the SSH configuration is correct, and check the minecraft server logs for further errors."
+            )
         }
     }
 

--- a/Sources/Bedrockifier/Model/ContainerConfig.swift
+++ b/Sources/Bedrockifier/Model/ContainerConfig.swift
@@ -41,9 +41,15 @@ public struct ToolConfig {
     }
 }
 
+public enum ContainerConnectionConfigKind {
+    case docker
+    case rcon
+    case ssh
+}
+
 public protocol ContainerConnectionConfig {
     var processPath: String { get }
-    var kind: String { get }
+    var kind: ContainerConnectionConfigKind { get }
     var newline: TerminalNewline { get }
     var password: String { get }
     func makeArguments() throws -> [String]
@@ -68,7 +74,7 @@ public struct DockerConnectionConfig: ContainerConnectionConfig {
         self.containerName = containerName
     }
 
-    public var kind: String { "docker" }
+    public var kind: ContainerConnectionConfigKind { .docker }
     public var newline: TerminalNewline { .default }
     public var processPath: String { dockerPath }
 
@@ -98,7 +104,7 @@ public struct RCONConnectionConfig: ContainerConnectionConfig {
         self.password = rconPassword
     }
 
-    public var kind: String { "rcon" }
+    public var kind: ContainerConnectionConfigKind { .rcon }
     public var newline: TerminalNewline { .ssh }
     public var processPath: String { rconPath }
 
@@ -139,7 +145,7 @@ public struct SSHConnectionConfig: ContainerConnectionConfig {
         self.password = sshPassword
     }
 
-    public var kind: String { "ssh" }
+    public var kind: ContainerConnectionConfigKind { .ssh }
     public var newline: TerminalNewline { .ssh }
     public var processPath: String { sshpassPath }
 
@@ -151,16 +157,8 @@ public struct SSHConnectionConfig: ContainerConnectionConfig {
         }
 
         return [
-            // sshpass arguments
-            "-e",
-            "-v",
-            // ssh arguments
-            sshPath,
-            "-p",
-            "\(parts[1])",
-            "-o",
-            "StrictHostKeyChecking=accept-new",
-            "bedrockifier@\(parts[0])"
+            String(parts[0]),
+            String(parts[1])
         ]
     }
 }

--- a/Sources/Bedrockifier/Model/ContainerConfig.swift
+++ b/Sources/Bedrockifier/Model/ContainerConfig.swift
@@ -126,7 +126,9 @@ public struct RCONConnectionConfig: ContainerConnectionConfig {
         guard let rconAddr = config.rcon else { return nil }
         let password = config.containerPassword()
         guard password != .none else {
-            Library.log.error("Container is configured for RCON, but was no password or password file was set. \(config.name)")
+            Library.log.error(
+                "Container is configured for RCON, but was no password or password file was set. \(config.name)"
+            )
             return nil
         }
 
@@ -140,7 +142,6 @@ public struct RCONConnectionConfig: ContainerConnectionConfig {
     public var processPath: String { rconPath }
 
     public func makeArguments() throws -> [String] {
-        // TODO: Do some checking here...
         let parts = address.split(whereSeparator: { $0 == ":" })
         guard parts.count == 2 else {
             throw ParseError.invalidHostname(address)
@@ -166,7 +167,9 @@ public struct SSHConnectionConfig: ContainerConnectionConfig {
         guard let sshAddr = config.ssh else { return nil }
         let password = config.containerPassword()
         guard password != .none else {
-            Library.log.error("Container is configured for SSH, but was no password or password file was set. \(config.name)")
+            Library.log.error(
+                "Container is configured for SSH, but was no password or password file was set. \(config.name)"
+            )
             return nil
         }
 
@@ -180,7 +183,6 @@ public struct SSHConnectionConfig: ContainerConnectionConfig {
     public var processPath: String { "" }
 
     public func makeArguments() throws -> [String] {
-        // TODO: Do some checking here...
         let parts = address.split(whereSeparator: { $0 == ":" })
         guard parts.count == 2 else {
             throw ParseError.invalidHostname(address)

--- a/Sources/Bedrockifier/Model/ContainerConfig.swift
+++ b/Sources/Bedrockifier/Model/ContainerConfig.swift
@@ -61,7 +61,7 @@ extension ContainerPassword {
             if let config = try? RconCliConfig.getYaml(from: fileUrl), let password = config.password {
                 return password
             } else {
-                Library.log.error("Unable to read the password from the YAML file at: \(fileUrl.path())")
+                Library.log.error("Unable to read the password from the YAML file at: \(fileUrl.path)")
                 throw ReadPasswordError.failedToReadFile
             }
         }

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -94,6 +94,7 @@ public class ContainerConnection {
     }
 
     public convenience init(containerName: String, config: ContainerConnectionConfig, kind: Kind, worlds: [String], extras: [String]?) throws {
+        Library.log.info("Starting Container Connection. newline = \(config.newline)")
         let terminal = try PseudoTerminal(identifier: containerName, newline: config.newline)
         try self.init(terminal: terminal,
                       containerName: containerName,

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -24,14 +24,12 @@
  */
 
 import Foundation
+import NIOCore
+import NIOPosix
 import PTYKit
 import ZIPFoundation
 
 public class ContainerConnection {
-    struct Strings {
-        static let dockerConnectError = "Got permission denied while trying to connect to the Docker daemon"
-    }
-
     public enum Kind {
         case bedrock
         case java
@@ -40,8 +38,8 @@ public class ContainerConnection {
     public let name: String
     let kind: Kind
 
-    public let terminal: PseudoTerminal
-    var terminalProcess: Process
+    private let terminal: ContainerTerminal
+    private var channel: ContainerChannel
     let connectionConfig: ContainerConnectionConfig
 
     let worlds: [URL]
@@ -49,16 +47,10 @@ public class ContainerConnection {
     var playerCount: Int
     public var lastBackup: Date
 
-    public var isRunning: Bool {
-        terminalProcess.isRunning
-    }
+    public var isRunning: Bool { channel.isConnected }
 
     private var controlTerminal: PseudoTerminal {
-        switch kind {
-        case .bedrock: fallthrough
-        case .java:
-            return terminal
-        }
+        terminal.terminal
     }
 
     public init(terminal: PseudoTerminal,
@@ -70,17 +62,35 @@ public class ContainerConnection {
         self.name = containerName
         self.connectionConfig = config
         self.kind = kind
-        self.terminal = terminal
         self.worlds = worlds.map({ URL(fileURLWithPath: $0) })
         self.extras = extras?.map({ URL(fileURLWithPath: $0) })
         self.playerCount = 0
         self.lastBackup = .distantPast
 
-        try self.terminal.setWindowSize(columns: 65000, rows: 24)
+        switch kind {
+        case .bedrock:
+            self.terminal = BedrockTerminal(terminal: terminal)
+        case .java:
+            self.terminal = JavaTerminal(terminal: terminal)
+        }
 
-        let processUrl = config.processUrl
-        let processArgs = try config.makeArguments()
-        self.terminalProcess = try Process(processUrl, arguments: processArgs, terminal: self.terminal)
+        switch connectionConfig.kind {
+        case .ssh:
+            let address = try connectionConfig.makeArguments()
+            guard let port = Int(address[1]) else {
+                throw ParseError.invalidSyntax
+            }
+            self.channel = SecureShellChannel(terminal: terminal, host: address[0], port: port, password: connectionConfig.password)
+        case .rcon:
+            fallthrough
+        case .docker:
+            let processUrl = config.processUrl
+            let processArgs = try config.makeArguments()
+            self.channel = try ProcessChannel(terminal: terminal, processUrl: processUrl, processArgs: processArgs)
+
+        }
+
+        try self.terminal.setWindowSize(columns: 65000, rows: 24)
     }
 
     public convenience init(containerName: String, config: ContainerConnectionConfig, kind: Kind, worlds: [String], extras: [String]?) throws {
@@ -93,52 +103,39 @@ public class ContainerConnection {
                       extras: extras)
     }
 
+    public func listen(for strings: [String], handler: @escaping TerminalListener) {
+        terminal.terminal.listen(for: strings, handler: handler)
+    }
+
     public func start() async throws {
         Library.log.debug("Starting Terminal Process. (container: \(name), kind: \(connectionConfig.kind))")
 
-        // Configure for SSH
-        var environment = terminalProcess.environment ?? [:]
-        environment["SSHPASS"] = connectionConfig.password
-        terminalProcess.environment = environment
-
-        try terminalProcess.run()
-
-        if connectionConfig.kind == "ssh" {
-            let result = await terminal.expect(["SSHPASS: detected prompt. Sending password.", "SSHPASS: read:"], timeout: 60.0)
-            if result == .noMatch {
-                Library.log.error("SSH connection doesn't seem to have been made properly.")
-            } else {
-                Library.log.info("SSH connection ready.")
-            }
-        }
-
+        try await channel.start()
         logTerminalSize()
     }
 
-    public func stop() async {
-        guard terminalProcess.isRunning else {
+    public func stop() async throws {
+        guard self.isRunning else {
             Library.log.warning("Attempted to stop a terminal process that isn't running. (container: \(name), kind: \(connectionConfig.kind))")
             return
         }
 
         Library.log.debug("Terminating Terminal Process. (container: \(name), kind: \(connectionConfig.kind))")
-        terminalProcess.terminate()
-        await terminal.waitForDetach()
+        try await channel.close()
+        await terminal.terminal.waitForDetach()
 
-        if terminalProcess.isRunning {
+        if self.isRunning {
             Library.log.error("Terminal Process Still Running. (container: \(name), kind: \(connectionConfig.kind))")
         }
     }
 
     public func reset() throws {
         Library.log.debug("Resetting Container Process. (container: \(name), kind: \(connectionConfig.kind))")
-        let processUrl = connectionConfig.processUrl
-        let processArgs = try connectionConfig.makeArguments()
-        self.terminalProcess = try Process(processUrl, arguments: processArgs, terminal: terminal)
+        try channel.reset()
     }
 
     public func cleanupIncompleteBackup(destination: URL) async throws {
-        guard terminalProcess.isRunning else {
+        guard self.isRunning else {
             throw ContainerError.processNotRunning
         }
 
@@ -151,7 +148,7 @@ public class ContainerConnection {
     }
 
     public func runBackup(destination: URL) async throws {
-        guard terminalProcess.isRunning else {
+        guard self.isRunning else {
             throw ContainerError.processNotRunning
         }
 
@@ -211,21 +208,11 @@ public class ContainerConnection {
     }
 
     public func pauseAutosave() async throws {
-        switch kind {
-        case .bedrock:
-            try await pauseSaveOnBedrock()
-        case .java:
-            try await pauseSaveOnJava()
-        }
+        try await terminal.pauseAutosave()
     }
 
     public func resumeAutosave() async throws {
-        switch kind {
-        case .bedrock:
-            try await resumeSaveOnBedrock()
-        case .java:
-            try await resumeSaveOnJava()
-        }
+        try await terminal.resumeAutosave()
     }
 
     public func incrementPlayerCount() -> Int {
@@ -266,85 +253,6 @@ public class ContainerConnection {
         return fileName
     }
 
-    private func pauseSaveOnBedrock() async throws {
-        // Start Save Hold
-        try controlTerminal.sendLine("save hold")
-        if try await expect(["Saving", "The command is already running"], timeout: 10.0) == .noMatch {
-            throw ContainerError.pauseFailed
-        }
-
-        // Wait for files to be ready
-        var attemptLimit = 3
-        while attemptLimit > 0 {
-            try controlTerminal.sendLine("save query")
-            if try await expect(["Files are now ready to be copied"], timeout: 10.0) == .noMatch {
-                attemptLimit -= 1
-            } else {
-                break
-            }
-        }
-
-        if attemptLimit < 0 {
-            throw ContainerError.saveNotCompleted
-        }
-    }
-
-    private func pauseSaveOnJava() async throws {
-        // Need a longer timeout on the flush in case server is still starting up
-        try controlTerminal.sendLine("save-all flush")
-        if try await expect(["Saved the game"], timeout: 30.0) == .noMatch {
-            throw ContainerError.pauseFailed
-        }
-
-        try controlTerminal.sendLine("save-off")
-        if try await expect(["Automatic saving is now disabled"], timeout: 10.0) == .noMatch {
-            throw ContainerError.pauseFailed
-        }
-    }
-
-    private func resumeSaveOnBedrock() async throws {
-        // Release Save Hold
-        try controlTerminal.sendLine("save resume")
-        let saveResumeStrings = [
-            "Changes to the level are resumed", // 1.17 and earlier
-            "Changes to the world are resumed", // 1.18 and later
-            "A previous save has not been completed"
-        ]
-        if try await expect(saveResumeStrings, timeout: 60.0) == .noMatch {
-            throw ContainerError.resumeFailed
-        }
-    }
-
-    private func resumeSaveOnJava() async throws {
-        try controlTerminal.sendLine("save-on")
-        let saveResumeStrings = [
-            "Automatic saving is now enabled",
-            "Saving is already turned on"
-        ]
-        if try await expect(saveResumeStrings, timeout: 60.0) == .noMatch {
-            throw ContainerError.resumeFailed
-        }
-    }
-
-    private func expect(_ expressions: [String], timeout: TimeInterval) async throws -> PseudoTerminal.ExpectResult {
-        let possibleErrors = [Strings.dockerConnectError: ContainerError.dockerConnectPermissionError]
-        let allExpectations = expressions + possibleErrors.keys
-
-        let result = await terminal.expect(allExpectations, timeout: timeout)
-        switch result {
-        case .noMatch:
-            break
-        case .match(let matchString):
-            for (errorKey, errorType) in possibleErrors {
-                if matchString.contains(errorKey) {
-                    throw errorType
-                }
-            }
-        }
-
-        return result
-    }
-
     public func isSaveHeld(destination: URL) -> Bool {
         let holdFile = holdFile(destination: destination)
         return FileManager.default.fileExists(atPath: holdFile.path)
@@ -372,7 +280,7 @@ public class ContainerConnection {
 
     private func logTerminalSize() {
         do {
-            let windowSize = try terminal.getWindowSize()
+            let windowSize = try terminal.terminal.getWindowSize()
             Library.log.debug("Docker Process Window Size Fetched. (cols = \(windowSize.ws_col), rows = \(windowSize.ws_row)")
         } catch {
             Library.log.debug("Failed to get terminal window size")

--- a/Sources/Bedrockifier/Model/ContainerTerminal.swift
+++ b/Sources/Bedrockifier/Model/ContainerTerminal.swift
@@ -1,0 +1,145 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+
+import PTYKit
+
+protocol ContainerTerminal {
+    var terminal: PseudoTerminal { get }
+
+    func pauseAutosave() async throws
+    func resumeAutosave() async throws
+}
+
+fileprivate struct ErrorStrings {
+    static let dockerConnectError = "Got permission denied while trying to connect to the Docker daemon"
+
+    static let possibleErrors = [
+        ErrorStrings.dockerConnectError: ContainerConnection.ContainerError.dockerConnectPermissionError
+    ]
+}
+
+internal extension ContainerTerminal {
+    func setWindowSize(columns: UInt16, rows: UInt16) throws {
+        return try terminal.setWindowSize(columns: columns, rows: rows)
+    }
+}
+
+fileprivate extension ContainerTerminal {
+    func expect(_ expressions: [String], timeout: TimeInterval) async throws -> PseudoTerminal.ExpectResult {
+        let allExpectations = expressions + ErrorStrings.possibleErrors.keys
+
+        let result = await terminal.expect(allExpectations, timeout: timeout)
+        switch result {
+        case .noMatch:
+            break
+        case .match(let matchString):
+            for (errorKey, errorType) in ErrorStrings.possibleErrors {
+                if matchString.contains(errorKey) {
+                    throw errorType
+                }
+            }
+        }
+
+        return result
+    }
+}
+
+struct BedrockTerminal: ContainerTerminal {
+    internal let terminal: PseudoTerminal
+
+    init(terminal: PseudoTerminal) {
+        self.terminal = terminal
+    }
+
+    func resumeAutosave() async throws {
+        // Release Save Hold
+        try terminal.sendLine("save resume")
+        let saveResumeStrings = [
+            "Changes to the level are resumed", // 1.17 and earlier
+            "Changes to the world are resumed", // 1.18 and later
+            "A previous save has not been completed"
+        ]
+        if try await expect(saveResumeStrings, timeout: 60.0) == .noMatch {
+            throw ContainerConnection.ContainerError.resumeFailed
+        }
+    }
+
+    func pauseAutosave() async throws {
+        // Start Save Hold
+        try terminal.sendLine("save hold")
+        if try await expect(["Saving", "The command is already running"], timeout: 10.0) == .noMatch {
+            throw ContainerConnection.ContainerError.pauseFailed
+        }
+
+        // Wait for files to be ready
+        var attemptLimit = 3
+        while attemptLimit > 0 {
+            try terminal.sendLine("save query")
+            if try await expect(["Files are now ready to be copied"], timeout: 10.0) == .noMatch {
+                attemptLimit -= 1
+            } else {
+                break
+            }
+        }
+
+        if attemptLimit < 0 {
+            throw ContainerConnection.ContainerError.saveNotCompleted
+        }
+    }
+}
+
+struct JavaTerminal: ContainerTerminal {
+    internal let terminal: PseudoTerminal
+
+    init(terminal: PseudoTerminal) {
+        self.terminal = terminal
+    }
+
+    func pauseAutosave() async throws {
+        // Need a longer timeout on the flush in case server is still starting up
+        try terminal.sendLine("save-all flush")
+        if try await expect(["Saved the game"], timeout: 30.0) == .noMatch {
+            throw ContainerConnection.ContainerError.pauseFailed
+        }
+
+        try terminal.sendLine("save-off")
+        if try await expect(["Automatic saving is now disabled"], timeout: 10.0) == .noMatch {
+            throw ContainerConnection.ContainerError.pauseFailed
+        }
+    }
+
+    func resumeAutosave() async throws {
+        try terminal.sendLine("save-on")
+        let saveResumeStrings = [
+            "Automatic saving is now enabled",
+            "Saving is already turned on"
+        ]
+        if try await expect(saveResumeStrings, timeout: 60.0) == .noMatch {
+            throw ContainerConnection.ContainerError.resumeFailed
+        }
+    }
+}

--- a/Sources/Bedrockifier/Model/ContainerTerminal.swift
+++ b/Sources/Bedrockifier/Model/ContainerTerminal.swift
@@ -34,7 +34,7 @@ protocol ContainerTerminal {
     func resumeAutosave() async throws
 }
 
-fileprivate struct ErrorStrings {
+private struct ErrorStrings {
     static let dockerConnectError = "Got permission denied while trying to connect to the Docker daemon"
 
     static let possibleErrors = [
@@ -48,7 +48,7 @@ internal extension ContainerTerminal {
     }
 }
 
-fileprivate extension ContainerTerminal {
+private extension ContainerTerminal {
     func expect(_ expressions: [String], timeout: TimeInterval) async throws -> PseudoTerminal.ExpectResult {
         let allExpectations = expressions + ErrorStrings.possibleErrors.keys
 
@@ -57,10 +57,8 @@ fileprivate extension ContainerTerminal {
         case .noMatch:
             break
         case .match(let matchString):
-            for (errorKey, errorType) in ErrorStrings.possibleErrors {
-                if matchString.contains(errorKey) {
-                    throw errorType
-                }
+            for (errorKey, errorType) in ErrorStrings.possibleErrors where matchString.contains(errorKey) {
+                throw errorType
             }
         }
 
@@ -70,10 +68,6 @@ fileprivate extension ContainerTerminal {
 
 struct BedrockTerminal: ContainerTerminal {
     internal let terminal: PseudoTerminal
-
-    init(terminal: PseudoTerminal) {
-        self.terminal = terminal
-    }
 
     func resumeAutosave() async throws {
         // Release Save Hold
@@ -114,10 +108,6 @@ struct BedrockTerminal: ContainerTerminal {
 
 struct JavaTerminal: ContainerTerminal {
     internal let terminal: PseudoTerminal
-
-    init(terminal: PseudoTerminal) {
-        self.terminal = terminal
-    }
 
     func pauseAutosave() async throws {
         // Need a longer timeout on the flush in case server is still starting up

--- a/Sources/Bedrockifier/Model/ServerExtras.swift
+++ b/Sources/Bedrockifier/Model/ServerExtras.swift
@@ -40,12 +40,11 @@ public struct ServerExtras: BackupItem {
         guard let nameRange = Range(match.range(at: 1), in: fileName) else {
             throw ServerExtrasError.invalidFilename
         }
-        
+
         self.name = String(fileName[nameRange])
         self.location = url
     }
 }
-
 
 extension ServerExtras {
     enum ServerExtrasError: Error {

--- a/Sources/Bedrockifier/Model/World.swift
+++ b/Sources/Bedrockifier/Model/World.swift
@@ -94,10 +94,7 @@ public struct World {
     }
 
     private static func fetchBedrockBackupName(location: URL) throws -> String {
-        guard let archive = Archive(url: location, accessMode: .read) else {
-            throw WorldError.invalidLevelArchive
-        }
-
+        let archive = try Archive(url: location, accessMode: .read)
         guard let levelnameEntry = archive["levelname.txt"] else {
             throw WorldError.missingLevelName
         }
@@ -113,10 +110,7 @@ public struct World {
     }
 
     private static func fetchJavaBackupName(location: URL) throws -> String {
-        guard let archive = Archive(url: location, accessMode: .read) else {
-            throw WorldError.invalidLevelArchive
-        }
-
+        let archive = try Archive(url: location, accessMode: .read)
         guard let levelDat = archive.first(where: { $0.path.hasSuffix("level.dat") }) else {
             throw WorldError.invalidLevelArchive
         }
@@ -147,7 +141,7 @@ extension World {
         let tempUrl = url.appendingPathExtension(World.partialPackExt)
 
         do {
-            try with(scopedOptional: Archive(url: tempUrl, accessMode: .create)) { archive in
+            try with(scopedObject: try Archive(url: tempUrl, accessMode: .create)) { archive in
                 if isBedrockFolder() {
                     try packBedrock(to: archive, progress: progress)
                 } else {
@@ -213,7 +207,7 @@ extension World {
                                           to: targetFolder,
                                           skipCRC32: false,
                                           progress: progress,
-                                          preferredEncoding: .utf8)
+                                          pathEncoding: .utf8)
         return try World(url: targetFolder)
     }
 
@@ -227,7 +221,7 @@ extension World {
                                           to: url,
                                           skipCRC32: false,
                                           progress: progress,
-                                          preferredEncoding: .utf8)
+                                          pathEncoding: .utf8)
 
         let finalFolder = url.appendingPathComponent(self.name)
         return try World(url: finalFolder)

--- a/Sources/Bedrockifier/Utilities/Invisibles.swift
+++ b/Sources/Bedrockifier/Utilities/Invisibles.swift
@@ -1,0 +1,34 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021-2022 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+
+extension String {
+    func withEscapedInvisibles() -> String {
+        self
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+    }
+}

--- a/Sources/Bedrockifier/Utilities/ScopedObject.swift
+++ b/Sources/Bedrockifier/Utilities/ScopedObject.swift
@@ -27,12 +27,12 @@ import Foundation
 
 struct NullScopedObjectError: Error {}
 
-func with<T>(scopedObject factory: @autoclosure () throws -> T, perform: (inout T) throws -> ()) rethrows {
+func with<T>(scopedObject factory: @autoclosure () throws -> T, perform: (inout T) throws -> Void) rethrows {
     var scopedObject = try factory()
     try perform(&scopedObject)
 }
 
-func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) -> ()) throws {
+func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) -> Void) throws {
     guard var scopedObject = factory() else {
         throw NullScopedObjectError()
     }
@@ -40,7 +40,7 @@ func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) -
     perform(&scopedObject)
 }
 
-func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) throws -> ()) throws {
+func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) throws -> Void) throws {
     guard var scopedObject = factory() else {
         throw NullScopedObjectError()
     }

--- a/Sources/Bedrockifier/Utilities/ScopedObject.swift
+++ b/Sources/Bedrockifier/Utilities/ScopedObject.swift
@@ -27,9 +27,9 @@ import Foundation
 
 struct NullScopedObjectError: Error {}
 
-func with<T>(scopedObject factory: @autoclosure () -> T, perform: (inout T) -> ()) {
-    var scopedObject = factory()
-    perform(&scopedObject)
+func with<T>(scopedObject factory: @autoclosure () throws -> T, perform: (inout T) throws -> ()) rethrows {
+    var scopedObject = try factory()
+    try perform(&scopedObject)
 }
 
 func with<T>(scopedOptional factory: @autoclosure () -> T?, perform: (inout T) -> ()) throws {

--- a/Sources/Bedrockifier/Utilities/StringUtils.swift
+++ b/Sources/Bedrockifier/Utilities/StringUtils.swift
@@ -33,6 +33,6 @@ extension String {
     }
 
     func convertNewlinesForSSH() -> String {
-        self.replacingOccurrences(of: "\n", with: "\r")
+        self.replacingOccurrences(of: "\n", with: "\r\n")
     }
 }

--- a/Sources/Bedrockifier/Utilities/StringUtils.swift
+++ b/Sources/Bedrockifier/Utilities/StringUtils.swift
@@ -31,4 +31,8 @@ extension String {
             .replacingOccurrences(of: "\n", with: "\\n")
             .replacingOccurrences(of: "\r", with: "\\r")
     }
+
+    func convertNewlinesForSSH() -> String {
+        self.replacingOccurrences(of: "\n", with: "\r")
+    }
 }

--- a/Sources/Bedrockifier/Utilities/StringUtils.swift
+++ b/Sources/Bedrockifier/Utilities/StringUtils.swift
@@ -28,8 +28,8 @@ import Foundation
 extension String {
     func withEscapedInvisibles() -> String {
         self
-            .replacingOccurrences(of: "\n", with: "\\n")
             .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\n", with: "\\n")
     }
 
     func convertNewlinesForSSH() -> String {

--- a/Sources/Service/BackupActor.swift
+++ b/Sources/Service/BackupActor.swift
@@ -103,7 +103,7 @@ actor BackupActor {
                         try await container.cleanupIncompleteBackup(destination: backupUrl)
 
                         if !wasRunning {
-                            await container.stop()
+                            try await container.stop()
                         }
                     } catch let error {
                         BackupService.logger.error("\(error.localizedDescription)")
@@ -201,7 +201,7 @@ actor BackupActor {
 
             do {
                 if !needsListeners {
-                    await container.stop()
+                    try await container.stop()
                     try container.reset()
                 }
             } catch let error {

--- a/Sources/Service/BackupActor.swift
+++ b/Sources/Service/BackupActor.swift
@@ -67,7 +67,7 @@ actor BackupActor {
             return container
         }
 
-        let _ = await currentBackup?.value
+        _ = await currentBackup?.value
         currentBackup = nil
     }
 
@@ -89,26 +89,24 @@ actor BackupActor {
 
     public func cleanupContainers() async {
         BackupService.logger.info("Checking for servers that might not be cleaned up")
-        for container in containers {
-            if container.isSaveHeld(destination: backupUrl) {
-                Task {
-                    BackupService.logger.info("\(container.name) is dirty, cleaning up")
-                    do {
-                        let wasRunning = container.isRunning
-                        if !wasRunning {
-                            try await container.start()
-                        }
-
-                        BackupService.logger.info("Cleaning up old backups for \(container.name)")
-                        try await container.cleanupIncompleteBackup(destination: backupUrl)
-
-                        if !wasRunning {
-                            try await container.stop()
-                        }
-                    } catch let error {
-                        BackupService.logger.error("\(error.localizedDescription)")
-                        BackupService.logger.error("Failed to clean up container \(container.name)")
+        for container in containers where container.isSaveHeld(destination: backupUrl) {
+            Task {
+                BackupService.logger.info("\(container.name) is dirty, cleaning up")
+                do {
+                    let wasRunning = container.isRunning
+                    if !wasRunning {
+                        try await container.start()
                     }
+
+                    BackupService.logger.info("Cleaning up old backups for \(container.name)")
+                    try await container.cleanupIncompleteBackup(destination: backupUrl)
+
+                    if !wasRunning {
+                        try await container.stop()
+                    }
+                } catch let error {
+                    BackupService.logger.error("\(error.localizedDescription)")
+                    BackupService.logger.error("Failed to clean up container \(container.name)")
                 }
             }
         }
@@ -144,7 +142,6 @@ actor BackupActor {
         }
     }
 
-
     private func runSingleBackup(container: ContainerConnection) async {
         guard shouldRunBackup(container: container) else {
             return
@@ -162,7 +159,7 @@ actor BackupActor {
             markUnhealthy()
         }
     }
-    
+
     public func needsListeners() -> Bool {
         return config.schedule?.onPlayerLogin == true
         || config.schedule?.onPlayerLogout == true
@@ -235,19 +232,25 @@ actor BackupActor {
         }
 
         if let trimJob = config.trim {
+            let trimAsk = Backups.Trim(
+                trimDays: trimJob.trimDays,
+                keepDays: trimJob.keepDays,
+                minKeep: trimJob.minKeep
+            )
+
             BackupService.logger.info("Performing Trim Jobs")
-            try Backups.trimBackups(World.self,
-                                    at: backupUrl,
-                                    dryRun: false,
-                                    trimDays: trimJob.trimDays,
-                                    keepDays: trimJob.keepDays,
-                                    minKeep: trimJob.minKeep)
-            try Backups.trimBackups(ServerExtras.self,
-                                    at: backupUrl,
-                                    dryRun: false,
-                                    trimDays: trimJob.trimDays,
-                                    keepDays: trimJob.keepDays,
-                                    minKeep: trimJob.minKeep)
+            try Backups.trimBackups(
+                World.self,
+                at: backupUrl,
+                dryRun: false,
+                trim: trimAsk
+            )
+            try Backups.trimBackups(
+                ServerExtras.self,
+                at: backupUrl,
+                dryRun: false,
+                trim: trimAsk
+            )
         }
     }
 

--- a/Sources/Service/EnvironmentConfig.swift
+++ b/Sources/Service/EnvironmentConfig.swift
@@ -32,18 +32,20 @@ struct EnvironmentConfig {
     let backupInterval: String?
     let dataDirectory: String
     let configFile: String
+    let hostKeysFile: String
+
     let dockerPath: String
     let rconPath: String
-    let sshPath: String
-    let sshpassPath: String
 
     init() {
         self.backupInterval = ProcessInfo.processInfo.environment["BACKUP_INTERVAL"]
         self.dataDirectory = ProcessInfo.processInfo.environment["DATA_DIR"] ?? "/backups"
         self.configFile = ProcessInfo.processInfo.environment["CONFIG_FILE"] ?? "config.yml"
+        self.hostKeysFile = ProcessInfo.processInfo.environment["HOST_KEYS_FILE"] ?? ".authorizedKeys"
+
+        // External Tools
         self.dockerPath = ProcessInfo.processInfo.environment["DOCKER_PATH"] ?? "/usr/bin/docker"
         self.rconPath = ProcessInfo.processInfo.environment["RCON_PATH"] ?? "/usr/local/bin/rcon-cli"
-        self.sshPath = ProcessInfo.processInfo.environment["SSH_PATH"] ?? "/usr/bin/ssh"
-        self.sshpassPath = ProcessInfo.processInfo.environment["SSHPASS_PATH"] ?? "/usr/bin/sshpass"
+
     }
 }

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -200,7 +200,7 @@ final class BackupService {
     private func startListenerBackups() async {
         BackupService.logger.info("Starting Listeners for Containers")
         for container in await backupActor.containers {
-            container.terminal.listen(for: Strings.listenerStrings) { content in
+            container.listen(for: Strings.listenerStrings) { content in
                 Task(priority: BackupService.backupPriority) {
                     await self.onListenerEvent(container: container, content: content)
                 }

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -138,10 +138,8 @@ final class BackupService {
 
         let allWorlds: [String] = bedrockWorlds + javaWorlds + oldWorlds
         var failedWorlds: [String] = []
-        for world in allWorlds {
-            if !FileManager.default.fileExists(atPath: world) {
-                failedWorlds.append(world)
-            }
+        for world in allWorlds where !FileManager.default.fileExists(atPath: world) {
+            failedWorlds.append(world)
         }
 
         if failedWorlds.count > 0 {

--- a/Sources/Tool/Commands/TrimCommand.swift
+++ b/Sources/Tool/Commands/TrimCommand.swift
@@ -57,17 +57,23 @@ public final class TrimCommand: Command {
     public func run(using context: CommandContext, signature: Signature) throws {
         let backupFolderUrl = URL(fileURLWithPath: signature.backupFolderPath, isDirectory: true)
 
-        try Backups.trimBackups(World.self,
-                                at: backupFolderUrl,
-                                dryRun: signature.dryRun,
-                                trimDays: signature.trimDays,
-                                keepDays: signature.keepDays,
-                                minKeep: signature.minKeep)
-        try Backups.trimBackups(ServerExtras.self,
-                                at: backupFolderUrl,
-                                dryRun: signature.dryRun,
-                                trimDays: signature.trimDays,
-                                keepDays: signature.keepDays,
-                                minKeep: signature.minKeep)
+        let trimAsk = Backups.Trim(
+            trimDays: signature.trimDays,
+            keepDays: signature.keepDays,
+            minKeep: signature.minKeep
+        )
+
+        try Backups.trimBackups(
+            World.self,
+            at: backupFolderUrl,
+            dryRun: signature.dryRun,
+            trim: trimAsk
+        )
+        try Backups.trimBackups(
+            ServerExtras.self,
+            at: backupFolderUrl,
+            dryRun: signature.dryRun,
+            trim: trimAsk
+        )
     }
 }

--- a/Tests/BedrockifierTests/ScopedObjectTests.swift
+++ b/Tests/BedrockifierTests/ScopedObjectTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import Bedrockifier
 
 final class MockScopedObject {
-    private let deinitHandler: () -> ()
+    private let deinitHandler: () -> Void
 
-    init(deinitHandler: @escaping () -> ()) {
+    init(deinitHandler: @escaping () -> Void) {
         self.deinitHandler = deinitHandler
     }
 


### PR DESCRIPTION
This adds a fully integrated SSH client to the backup server, allowing the server to do backups without the "bedrockifier" user that the OpenSSH client requires. It also tightens security by not needing to provide a password to another process, and can directly do so over the SSH channel.

This also fixes a bug with SSH/RCON support where if the password file changed between connection attempts, it wouldn't read the new password and just repeatedly fail.  

This requires [2024.4.0](https://github.com/itzg/docker-minecraft-server/releases/tag/2024.4.0) or later when using Java, or 'latest' when using Bedrock (from after March 12, 2024). Those versions include ECDSA support for host keys, which is required by Swift-NIO-SSH (no RSA support at this time). 