### PR TITLE
Support Separate Configuration Directory

### DIFF
--- a/Docker/entry.sh
+++ b/Docker/entry.sh
@@ -4,5 +4,11 @@
 #
 # Used by the docker container
 
+# Figure out which folder to match
+FOLDER_TO_MATCH=/backups
+if [ -d /data ]; then
+  FOLDER_TO_MATCH=/data
+fi
+
 # Execute
-/usr/local/bin/entrypoint-demoter --match /backups --debug --stdin-on-term stop /opt/bedrock/bedrockifierd
+/usr/local/bin/entrypoint-demoter --match $FOLDER_TO_MATCH --debug --stdin-on-term stop /opt/bedrock/bedrockifierd

--- a/Docker/healthcheck.sh
+++ b/Docker/healthcheck.sh
@@ -10,9 +10,9 @@ if [ "${DEBUG:-false}" == "true" ]; then
   set -x
 fi
 
-: "${DATA_DIR:=/backups}"
+: "${CONFIG_DIR:=/config}"
 
-if [ ! -e "${DATA_DIR}/.service_is_healthy" ]; then
+if [ ! -e "${CONFIG_DIR}/.service_is_healthy" ]; then
   exit 1
 fi
 

--- a/Sources/Service/BackupActor.swift
+++ b/Sources/Service/BackupActor.swift
@@ -36,10 +36,10 @@ actor BackupActor {
     private var currentBackup: Task<ContainerConnection, Never>?
     private var currentFullBackup: Task<Void, Never>?
 
-    init(config: BackupConfig, destination: URL) {
+    init(config: BackupConfig, configDir: URL, dataDir: URL) {
         self.config = config
-        self.backupUrl = destination
-        self.healthFileUrl = destination.appendingPathComponent(".service_is_healthy")
+        self.backupUrl = dataDir
+        self.healthFileUrl = configDir.appendingPathComponent(".service_is_healthy")
         self.containers = []
     }
 

--- a/Sources/Service/EnvironmentConfig.swift
+++ b/Sources/Service/EnvironmentConfig.swift
@@ -29,23 +29,74 @@ import Foundation
 struct EnvironmentConfig {
     static let fallbackConfigFile = "config.json"
 
-    let backupInterval: String?
-    let dataDirectory: String
-    let configFile: String
-    let hostKeysFile: String
+    static let dataDirVariable = "DATA_DIR"
 
+    static let defaultConfigPath = "/config"
+    static let defaultDataPath = "/data"
+    static let defaultOldDataPath = "/backups"
+
+
+    // External Tools in Container
     let dockerPath: String
     let rconPath: String
 
-    init() {
-        self.backupInterval = ProcessInfo.processInfo.environment["BACKUP_INTERVAL"]
-        self.dataDirectory = ProcessInfo.processInfo.environment["DATA_DIR"] ?? "/backups"
-        self.configFile = ProcessInfo.processInfo.environment["CONFIG_FILE"] ?? "config.yml"
-        self.hostKeysFile = ProcessInfo.processInfo.environment["HOST_KEYS_FILE"] ?? ".authorizedKeys"
+    // Config Folder Settings
+    let configDirectory: String
+    let configFile: String
+    let hostKeysFile: String
 
-        // External Tools
+    // Data Folder Settings
+    let dataDirectory: String
+
+    // Deprecated Settings
+    let backupInterval: String?
+
+    init() {
+        // External Tools in Container
         self.dockerPath = ProcessInfo.processInfo.environment["DOCKER_PATH"] ?? "/usr/bin/docker"
         self.rconPath = ProcessInfo.processInfo.environment["RCON_PATH"] ?? "/usr/local/bin/rcon-cli"
 
+        // Config Folder Settings
+        self.configDirectory = EnvironmentConfig.configDirectory()
+        self.configFile = ProcessInfo.processInfo.environment["CONFIG_FILE"] ?? "config.yml"
+        self.hostKeysFile = ProcessInfo.processInfo.environment["HOST_KEYS_FILE"] ?? ".authorizedKeys"
+
+        // Data Folder Settings
+        self.dataDirectory = EnvironmentConfig.dataDirectory()
+
+        // Deprecated Settings
+        self.backupInterval = ProcessInfo.processInfo.environment["BACKUP_INTERVAL"]
+    }
+
+    private static func configDirectory() -> String {
+        if let envPath = ProcessInfo.processInfo.environment["CONFIG_DIR"] {
+            return envPath
+        }
+
+        if FileManager.default.fileExists(atPath: defaultConfigPath) {
+            return defaultConfigPath
+        }
+
+        if let dataEnvPath = ProcessInfo.processInfo.environment[dataDirVariable] {
+            return dataEnvPath
+        }
+
+        if FileManager.default.fileExists(atPath: defaultDataPath) {
+            return defaultDataPath
+        }
+
+        return defaultOldDataPath
+    }
+
+    private static func dataDirectory() -> String {
+        if let dataEnvPath = ProcessInfo.processInfo.environment[dataDirVariable] {
+            return dataEnvPath
+        }
+
+        if FileManager.default.fileExists(atPath: defaultDataPath) {
+            return defaultDataPath
+        }
+
+        return defaultOldDataPath
     }
 }

--- a/Sources/Service/EnvironmentConfig.swift
+++ b/Sources/Service/EnvironmentConfig.swift
@@ -35,7 +35,6 @@ struct EnvironmentConfig {
     static let defaultDataPath = "/data"
     static let defaultOldDataPath = "/backups"
 
-
     // External Tools in Container
     let dockerPath: String
     let rconPath: String

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -46,18 +46,18 @@ final class BackupService {
 
     let config: BackupConfig
     let environment: EnvironmentConfig
-    let backupUrl: URL
+    let dataUrl: URL
     let tools: ToolConfig
     let backupActor: BackupActor
 
     var intervalTimer: ServiceTimer<String>?
 
-    init(config: BackupConfig, backupUrl: URL, tools: ToolConfig) {
+    init(config: BackupConfig, configUrl: URL, dataUrl: URL, tools: ToolConfig) {
         self.config = config
         self.environment = EnvironmentConfig()
-        self.backupUrl = backupUrl
+        self.dataUrl = dataUrl
         self.tools = tools
-        self.backupActor = BackupActor(config: config, destination: backupUrl)
+        self.backupActor = BackupActor(config: config, configDir: configUrl, dataDir: dataUrl)
     }
 
     public func run() throws {

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -46,6 +46,9 @@ struct Server: ParsableCommand {
     @Option(name: .shortAndLong, help: "Path to rcon-cli")
     var rconPath: String?
 
+    @Option(name: .shortAndLong, help: "Folder to read config from")
+    var configFolder: String?
+
     @Option(name: .shortAndLong, help: "Folder to write backups to")
     var backupPath: String?
 
@@ -103,7 +106,8 @@ struct Server: ParsableCommand {
         do {
             let service = BackupService(
                 config: config,
-                backupUrl: backupUrl,
+                configUrl: URL(fileURLWithPath: environment.configDirectory),
+                dataUrl: backupUrl,
                 tools: tools
             )
 
@@ -129,8 +133,8 @@ struct Server: ParsableCommand {
             return URL(fileURLWithPath: configPath)
         }
 
-        let dataDirectory = URL(fileURLWithPath: environment.dataDirectory)
-        let defaultPath = dataDirectory.appendingPathComponent(environment.configFile).path
+        let configDirectory = URL(fileURLWithPath: self.configFolder ?? environment.configDirectory)
+        let defaultPath = configDirectory.appendingPathComponent(environment.configFile).path
         if FileManager.default.fileExists(atPath: defaultPath) {
             return URL(fileURLWithPath: defaultPath)
         }
@@ -138,7 +142,7 @@ struct Server: ParsableCommand {
         Server.logger.warning(
             "\(environment.configFile) not found, using older default: \(EnvironmentConfig.fallbackConfigFile)"
         )
-        return dataDirectory.appendingPathComponent(EnvironmentConfig.fallbackConfigFile)
+        return configDirectory.appendingPathComponent(EnvironmentConfig.fallbackConfigFile)
     }
 
     private func getHostKeyFileUrl(environment: EnvironmentConfig) -> URL {
@@ -146,8 +150,8 @@ struct Server: ParsableCommand {
             return URL(fileURLWithPath: hostKeysPath)
         }
 
-        let dataDirectory = URL(fileURLWithPath: environment.dataDirectory)
-        let defaultPath = dataDirectory.appendingPathComponent(environment.hostKeysFile).path
+        let configDirectory = URL(fileURLWithPath: environment.configDirectory)
+        let defaultPath = configDirectory.appendingPathComponent(environment.hostKeysFile).path
         return URL(fileURLWithPath: defaultPath)
     }
 


### PR DESCRIPTION
Adds the ability to use a different configuration directory from the backup directory.

- /config is the default configuration directory, using /data and /backups as fallbacks
- /data is now the default backup/data directory, using /backups as the fallback.
