### PR TITLE
Support Initial Backups

### DIFF
--- a/Sources/Bedrockifier/Model/ScheduleConfig.swift
+++ b/Sources/Bedrockifier/Model/ScheduleConfig.swift
@@ -30,6 +30,7 @@ public struct ScheduleConfig: Codable {
     public var daily: DayTime?
     public var interval: String?
     public var startupDelay: String?
+    public var runInitialBackup: Bool?
 
     // Event Based Schedules
     public var onPlayerLogin: Bool?

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -97,7 +97,7 @@ final class BackupService {
                     }
 
                     if let minInterval = try schedule.parseMinInterval() {
-                        BackupService.logger.info("Backup Minimum Interval is \(minInterval) seconds")
+                        BackupService.logger.info("Backup Minimum Interval is \(minInterval) seconds.")
                     }
                 } else {
                     // Without the schedule, we have to assume the docker container specifies an interval
@@ -112,6 +112,11 @@ final class BackupService {
                 await MainActor.run {
                     exit(-1)
                 }
+            }
+
+            if config.schedule?.runInitialBackup == true {
+                BackupService.logger.info("Performing Initial Backup...")
+                await self.backupActor.backupAllContainers(isDaily: true)
             }
         }
 


### PR DESCRIPTION
Adds support for a new flag in the configuration YAML:

```
schedule:
  runInitialBackup: true
```

Setting this to true will cause the service to trigger a backup after `startupDelay`. In cases where a user wants this behavior, they should also use `startupDelay` or `depends_on: healthy` setup to avoid attempting to start a backup too early. 