### PR TITLE
Add Basic HTTP Request Handling on 8080

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Bedrockifier",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v14)
     ],
     products: [
             // The external product of our package is an importable
@@ -25,6 +25,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssh.git", from: "0.8.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
         .package(url: "https://github.com/Kaiede/PTYKit.git", branch: "master"),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.3"),
@@ -47,7 +48,8 @@ let package = Package(
             dependencies: [
                 "Bedrockifier",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Backtrace", package: "swift-backtrace")
+                .product(name: "Backtrace", package: "swift-backtrace"),
+                .product(name: "Hummingbird", package: "hummingbird")
             ]
         ),
         .target(

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -60,6 +60,7 @@ public struct BackupConfig: Codable {
     public var sshPath: String?
     public var sshpassPath: String?
     public var backupPath: String?
+    public var tokenPath: String?
     public var servers: ServerConfig?
     public var containers: ServerContainersConfig?
     public var trim: TrimConfig?

--- a/Sources/Service/ServiceState.swift
+++ b/Sources/Service/ServiceState.swift
@@ -1,0 +1,40 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+import Hummingbird
+
+struct LastBackupResult: Codable {
+    var date: Date
+    var success: Bool
+    var sizes: [String: UInt64]
+    var totalSize: UInt64
+}
+
+struct ServiceState: Codable {
+    var lastBackup: LastBackupResult?
+}
+
+extension ServiceState: ResponseEncodable {}

--- a/Sources/Service/TokenCheckingMiddleware.swift
+++ b/Sources/Service/TokenCheckingMiddleware.swift
@@ -1,0 +1,71 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2021 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+import Hummingbird
+
+struct TokenCheckingMiddleware<Context>: RouterMiddleware {
+    private let tokenFile: URL
+
+    init(tokenFile: URL) {
+        self.tokenFile = tokenFile
+    }
+
+    public static func generateToken() -> String {
+        let token = UUID().uuid
+        var tokenData = Data(count: 16)
+        tokenData[0] = token.0
+        tokenData[1] = token.1
+        tokenData[2] = token.2
+        tokenData[3] = token.3
+        tokenData[4] = token.4
+        tokenData[5] = token.5
+        tokenData[6] = token.6
+        tokenData[7] = token.7
+        tokenData[8] = token.8
+        tokenData[9] = token.9
+        tokenData[10] = token.10
+        tokenData[11] = token.11
+        tokenData[12] = token.12
+        tokenData[13] = token.13
+        tokenData[14] = token.14
+        tokenData[15] = token.15
+        return tokenData.base64EncodedString()
+    }
+
+    public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
+        guard let currentToken = try? String(contentsOf: tokenFile) else {
+            throw HTTPError(.internalServerError, message: "Cannot accept requests at this time.")
+        }
+
+        guard let token = request.headers[.authorization], token == "Bearer \(currentToken)" else {
+            throw HTTPError(.badRequest, message: "Invalid authorization.")
+        }
+
+        return try await next(request, context)
+    }
+
+
+}

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -106,7 +106,7 @@ struct Server: ParsableCommand {
         do {
             let service = BackupService(
                 config: config,
-                configUrl: URL(fileURLWithPath: environment.configDirectory),
+                configDir: URL(fileURLWithPath: environment.configDirectory),
                 dataUrl: backupUrl,
                 tools: tools
             )


### PR DESCRIPTION
Provides an implementation of `/health` and `/live` for monitoring service health. It also provides a partial implementation of `/status` although it doesn't report sizes of backups properly yet, just provides when the last backup occurred, if it was successful, and which containers were backed up. 

It also implements `/start-backup` which requires the caller provide the correct token. The token is generated randomly at the start of the service, and written to a file. The file path can be configured using `tokenPath` in the configuration file, but by default it creates a `.bedrockifierToken` file adjacent to the configuration file, similar to `.service_is_healthy` 

To kick off a backup, a user with access to the configuration directory, and curl can do something like the following. 

```
curl http://{IPADDRESS}:8080/start-backup
   -H "Authorization: Bearer $(cat configDir/.bedrockifierToken)"
```