### PR TITLE
Hummingbird v2

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -17,6 +17,7 @@ ARG TARGETVARIANT
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl \
     docker.io \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -96,7 +96,7 @@ final class BackupService {
         let application = Application(
             router: router,
             configuration: .init(
-                address: .hostname("127.0.0.1", port: 8080),
+                address: .hostname("0.0.0.0", port: 8080),
                 serverName: "Bedrockifier"
             ),
             logger: BackupService.logger


### PR DESCRIPTION
Unbinds the HTTP port from localhost so that services external to the container can actually talk to it.

Adds curl to the docker container to make it possible to start adding scripts that ping the HTTP port via docker exec, such as adding a "backup now" script and migrating the health checking script to use the HTTP result rather than the temporary file.