### PR TITLE
Only install Docker CLI

### DIFF
--- a/Docker/install-dependencies.sh
+++ b/Docker/install-dependencies.sh
@@ -21,7 +21,7 @@ else
 
     # Docker packages
     apt update
-    apt install -y docker-ce docker-ce-cli containerd.io
+    apt install -y docker-ce-cli
 fi
 
 apt clean


### PR DESCRIPTION
Revert the bloat from converting over to the offical docker repository, and only include the CLI package.