### PR TITLE
Use Static Swift Build

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,7 +5,7 @@ FROM $swift_image AS builder
 WORKDIR /project
 
 ADD . /project
-RUN swift build -c release -Xswiftc -g --static-swift-stdlib
+RUN swift build -c release --static-swift-stdlib
 
 ###### RUNTIME CONTAINER
 FROM $swift_image-slim

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,7 +5,7 @@ FROM $swift_image AS builder
 WORKDIR /project
 
 ADD . /project
-RUN swift build -c release -Xswiftc -g
+RUN swift build -c release -Xswiftc -g --static-swift-stdlib
 
 ###### RUNTIME CONTAINER
 FROM $swift_image-slim

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,6 @@ let package = Package(
             dependencies: [
                 "Bedrockifier",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Backtrace", package: "swift-backtrace"),
                 .product(name: "Hummingbird", package: "hummingbird")
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,6 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.22.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.1"),
         .package(url: "https://github.com/Kaiede/PTYKit.git", branch: "master"),
-        .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.5"),
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.16.0"),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.20")
     ],

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -24,7 +24,6 @@
  */
 
 import ArgumentParser
-import Backtrace
 import Foundation
 import Logging
 import PTYKit


### PR DESCRIPTION
General maintenance. Swift 5.9 adds in backtracing directly, so we don't need the Backtracing package.

By using a static build, we can ditch using the swift-slim image for deployment, and could start using a simpler/smaller base image. 