### PR TITLE
Migrate to Swift NIO Docker Client

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,7 +5,7 @@ FROM $swift_image AS builder
 WORKDIR /project
 
 ADD . /project
-RUN swift build -c release -Xswiftc -g
+RUN swift build -c release
 
 ###### DEPENDENCY FETCHER
 FROM $swift_image-slim AS deps

--- a/Docker/install-dependencies.sh
+++ b/Docker/install-dependencies.sh
@@ -1,28 +1,11 @@
 #!/bin/bash
 #
-# Make
+# Install dependencies from package manager
 set -xeuo pipefail
 
 apt update
 
-if [ "$1" == "slim" ]; then
-    apt install -y curl
-else
-    apt install -y ca-certificates curl
-
-    # Docker Repo
-    install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-    chmod a+r /etc/apt/keyrings/docker.asc
-
-    # Add the repository to Apt sources:
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-        tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-    # Docker packages
-    apt update
-    apt install -y docker-ce-cli
-fi
+apt install -y curl
 
 apt clean
 rm -rf /var/lib/apt/lists/*

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,6 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.22.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.1"),
         .package(url: "https://github.com/Kaiede/PTYKit.git", branch: "master"),
-        .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.5"),
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.16.0"),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.20")
     ],
@@ -48,7 +47,6 @@ let package = Package(
             dependencies: [
                 "Bedrockifier",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Backtrace", package: "swift-backtrace"),
                 .product(name: "Hummingbird", package: "hummingbird")
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.99.0"),
         .package(url: "https://github.com/apple/swift-nio-ssh.git", from: "0.13.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.22.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.1"),
@@ -54,6 +55,7 @@ let package = Package(
             name: "Bedrockifier",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOSSH", package: "swift-nio-ssh"),
                 .product(name: "PTYKit", package: "PTYKit"),
                 .product(name: "Yams", package: "Yams"),

--- a/Sources/Bedrockifier/Client/DockerClient.swift
+++ b/Sources/Bedrockifier/Client/DockerClient.swift
@@ -26,6 +26,7 @@
 import Foundation
 
 import NIOCore
+import NIOHTTP1
 import NIOPosix
 import PTYKit
 
@@ -33,6 +34,26 @@ enum DockerClientError: Error {
     case invalidResponse
     case upgradeFailed(String)
     case connectionClosed
+    case inspectFailed(String)
+    case stdinUnavailable(String)
+}
+
+private struct ContainerInspect: Decodable {
+    struct Config: Decodable {
+        let tty: Bool
+        let openStdin: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case tty = "Tty"
+            case openStdin = "OpenStdin"
+        }
+    }
+
+    let config: Config
+
+    enum CodingKeys: String, CodingKey {
+        case config = "Config"
+    }
 }
 
 final class DockerClient {
@@ -74,27 +95,41 @@ final class DockerClient {
         defer { self.isConnecting = false }
 
         self.attachedContainer = containerName
-        Library.log.info("Connecting Docker attach for container '\(containerName)' via \(socketPath)")
+        Library.log.info("Connecting to Docker container '\(containerName)' via \(socketPath)")
 
         let terminal = self.terminal
-        let upgradePromise = group.next().makePromise(of: Void.self)
-        let upgradeHandler = DockerAttachUpgradeHandler(
+        let connectPromise = group.next().makePromise(of: Void.self)
+
+        let httpEncoder = HTTPRequestEncoder()
+        let httpDecoder = ByteToMessageHandler(
+            HTTPResponseDecoder(leftOverBytesStrategy: .forwardBytes)
+        )
+
+        let connectionHandler = DockerConnectionHandler(
             containerName: containerName,
-            upgradePromise: upgradePromise
-        ) { channel in
-            channel.pipeline.addHandler(TerminalHandler(terminal: terminal))
+            connectPromise: connectPromise,
+            httpEncoder: httpEncoder,
+            httpDecoder: httpDecoder
+        ) { channel, isTTY in
+            if isTTY {
+                return channel.pipeline.addHandler(TerminalHandler(terminal: terminal))
+            }
+            return channel.pipeline.addHandlers([
+                DockerStreamDemuxHandler(),
+                TerminalHandler(terminal: terminal)
+            ])
         }
 
         let bootstrap = ClientBootstrap(group: group)
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_KEEPALIVE), value: 1)
+            .channelOption(.socketOption(.so_keepalive), value: 1)
             .channelInitializer { channel in
-                channel.pipeline.addHandler(upgradeHandler)
+                channel.pipeline.addHandlers([httpEncoder, httpDecoder, connectionHandler])
             }
 
         Library.log.trace("Opening docker socket...")
         let channel = try await bootstrap.connect(unixDomainSocketPath: socketPath).get()
         do {
-            try await upgradePromise.futureResult.get()
+            try await connectPromise.futureResult.get()
         } catch {
             try? await channel.close()
             throw error
@@ -104,6 +139,7 @@ final class DockerClient {
         self.connectedChannel = channel
         channel.closeFuture.whenComplete { [weak self, weak channel] _ in
             guard let self = self, let channel = channel else { return }
+
             let wasActiveChannel = self.connectedChannel === channel
             if wasActiveChannel {
                 self.connectedChannel = nil
@@ -111,7 +147,7 @@ final class DockerClient {
             }
             Library.log.warning("Docker connection closed.")
         }
-        
+
         Library.log.info("Attached to container '\(containerName)'.")
     }
 
@@ -164,142 +200,258 @@ final class DockerClient {
     }
 }
 
-/// Sends the Docker attach request, parses the HTTP/1.1 response headers,
-/// validates the 101 upgrade, then swaps itself out for the supplied post-upgrade
-/// handlers so the rest of the pipeline sees a raw byte stream to the container.
-final class DockerAttachUpgradeHandler: ChannelInboundHandler, RemovableChannelHandler {
-    typealias InboundIn = ByteBuffer
-    typealias InboundOut = ByteBuffer
-    typealias OutboundOut = ByteBuffer
+/// Drives the Docker attach lifecycle on top of NIOHTTP1:
+///   1. GET `/containers/{name}/json` -> parse `Config.Tty` / `Config.OpenStdin`.
+///   2. POST `/containers/{name}/attach` with `Upgrade: tcp` -> wait for 101.
+///   3. Reconfigure the pipeline: install the post-upgrade handlers, then remove
+///      the HTTP codec (forwarding any unread bytes as raw ByteBuffers) and self.
+final class DockerConnectionHandler: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPClientResponsePart
+    typealias OutboundOut = HTTPClientRequestPart
+
+    private enum State {
+        case awaitingInspectHead
+        case readingInspectBody
+        case awaitingUpgradeHead
+        case awaitingUpgradeEnd
+        case reconfiguring
+        case streaming
+        case failed
+    }
 
     private let containerName: String
-    private let upgradePromise: EventLoopPromise<Void>
-    private let installPostUpgradeHandlers: (Channel) -> EventLoopFuture<Void>
+    private let connectPromise: EventLoopPromise<Void>
+    private let httpEncoder: HTTPRequestEncoder
+    private let httpDecoder: ByteToMessageHandler<HTTPResponseDecoder>
+    private let installPostUpgradeHandlers: (Channel, Bool) -> EventLoopFuture<Void>
 
-    private var responseBuffer: ByteBuffer?
-    private var upgradeComplete = false
+    private var state: State = .awaitingInspectHead
+    private var inspectBody: ByteBuffer?
+    private var isTTY = false
 
     init(
         containerName: String,
-        upgradePromise: EventLoopPromise<Void>,
-        installPostUpgradeHandlers: @escaping (Channel) -> EventLoopFuture<Void>
+        connectPromise: EventLoopPromise<Void>,
+        httpEncoder: HTTPRequestEncoder,
+        httpDecoder: ByteToMessageHandler<HTTPResponseDecoder>,
+        installPostUpgradeHandlers: @escaping (Channel, Bool) -> EventLoopFuture<Void>
     ) {
         self.containerName = containerName
-        self.upgradePromise = upgradePromise
+        self.connectPromise = connectPromise
+        self.httpEncoder = httpEncoder
+        self.httpDecoder = httpDecoder
         self.installPostUpgradeHandlers = installPostUpgradeHandlers
     }
 
     func channelActive(context: ChannelHandlerContext) {
-        Library.log.trace("Starting docker connection upgrade.")
-        let path = "/containers/\(containerName)/attach?stream=1&stdin=1&stdout=1&stderr=1"
-        let request =
-            "POST \(path) HTTP/1.1\r\n" +
-            "Host: docker\r\n" +
-            "Connection: Upgrade\r\n" +
-            "Upgrade: tcp\r\n" +
-            "Content-Length: 0\r\n" +
-            "\r\n"
-
-        var buffer = context.channel.allocator.buffer(capacity: request.utf8.count)
-        buffer.writeString(request)
-        context.writeAndFlush(wrapOutboundOut(buffer), promise: nil)
+        sendInspectRequest(context: context)
         context.fireChannelActive()
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        var inbound = unwrapInboundIn(data)
+        let part = unwrapInboundIn(data)
 
-        if upgradeComplete {
-            // Post-upgrade reads should already be flowing past us. Pass through defensively.
-            context.fireChannelRead(wrapInboundOut(inbound))
-            return
-        }
-
-        if responseBuffer == nil {
-            responseBuffer = inbound
-        } else {
-            responseBuffer?.writeBuffer(&inbound)
-        }
-
-        guard var buffer = responseBuffer else { return }
-        guard let headerEnd = indexOfCRLFCRLF(in: buffer.readableBytesView) else {
-            // Wait for more data; keep accumulating.
-            responseBuffer = buffer
-            return
-        }
-
-        let headerLength = headerEnd + 4
-        let headerBytes = buffer.readBytes(length: headerLength) ?? []
-        let leftover = buffer.readableBytes > 0 ? buffer.readSlice(length: buffer.readableBytes) : nil
-        responseBuffer = nil
-
-        guard let headers = String(bytes: headerBytes, encoding: .utf8) else {
-            upgradePromise.fail(DockerClientError.invalidResponse)
-            context.close(promise: nil)
-            return
-        }
-
-        let statusLine = headers.split(whereSeparator: { $0 == "\r" || $0 == "\n" }).first.map(String.init) ?? ""
-        let parts = statusLine.split(separator: " ", maxSplits: 2).map(String.init)
-        guard parts.count >= 2, parts[1] == "101" else {
-            Library.log.error("Docker attach upgrade failed: '\(statusLine)'")
-            upgradePromise.fail(DockerClientError.upgradeFailed(statusLine))
-            context.close(promise: nil)
-            return
-        }
-
-        Library.log.debug("Docker attach upgrade accepted.")
-        upgradeComplete = true
-
-        installPostUpgradeHandlers(context.channel).whenComplete { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success:
-                // Forward any bytes that arrived after the headers — they belong to the post-upgrade pipeline.
-                if let leftover = leftover, leftover.readableBytes > 0 {
-                    context.fireChannelRead(self.wrapInboundOut(leftover))
-                }
-                context.pipeline.removeHandler(self).whenComplete { _ in
-                    Library.log.debug("Docker attach upgrade completed.")
-                    Library.log.debug("\(context.pipeline.debugDescription)")
-                    self.upgradePromise.succeed(())
-                }
-            case .failure(let error):
-                self.upgradePromise.fail(error)
-                context.close(promise: nil)
+        switch state {
+        case .awaitingInspectHead:
+            guard case .head(let head) = part else {
+                fail(DockerClientError.invalidResponse, context: context)
+                return
             }
+            guard head.status == .ok else {
+                Library.log.error("Docker inspect failed: \(head.status)")
+                fail(DockerClientError.inspectFailed("\(head.status)"), context: context)
+                return
+            }
+            state = .readingInspectBody
+
+        case .readingInspectBody:
+            switch part {
+            case .body(var chunk):
+                if inspectBody == nil {
+                    inspectBody = chunk
+                } else {
+                    inspectBody?.writeBuffer(&chunk)
+                }
+            case .end:
+                finishInspect(context: context)
+            case .head:
+                fail(DockerClientError.invalidResponse, context: context)
+            }
+
+        case .awaitingUpgradeHead:
+            guard case .head(let head) = part else {
+                // .body or .end before .head is malformed.
+                fail(DockerClientError.invalidResponse, context: context)
+                return
+            }
+            guard head.status == .switchingProtocols else {
+                Library.log.error("Docker attach upgrade failed: \(head.status)")
+                fail(DockerClientError.upgradeFailed("\(head.status)"), context: context)
+                return
+            }
+            state = .awaitingUpgradeEnd
+
+        case .awaitingUpgradeEnd:
+            if case .end = part {
+                beginUpgrade(context: context)
+            }
+            // Ignore any stray .body
+
+        case .reconfiguring, .streaming, .failed:
+            return
         }
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-        if !upgradeComplete {
-            upgradePromise.fail(error)
-        }
         Library.log.error("Docker pipeline error: \(error.localizedDescription)")
-        context.close(promise: nil)
+        fail(error, context: context)
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-        if !upgradeComplete {
-            upgradePromise.fail(DockerClientError.connectionClosed)
+        if state != .streaming, state != .failed {
+            state = .failed
+            connectPromise.fail(DockerClientError.connectionClosed)
         }
         context.fireChannelInactive()
     }
 
-    private func indexOfCRLFCRLF(in bytes: ByteBufferView) -> Int? {
-        // \r\n\r\n
-        let needle: [UInt8] = [0x0D, 0x0A, 0x0D, 0x0A]
-        guard bytes.count >= needle.count else { return nil }
-        let start = bytes.startIndex
-        for offset in 0...(bytes.count - needle.count) {
-            let i0 = bytes.index(start, offsetBy: offset)
-            if bytes[i0] == needle[0]
-                && bytes[bytes.index(i0, offsetBy: 1)] == needle[1]
-                && bytes[bytes.index(i0, offsetBy: 2)] == needle[2]
-                && bytes[bytes.index(i0, offsetBy: 3)] == needle[3] {
-                return offset
+    private func sendInspectRequest(context: ChannelHandlerContext) {
+        Library.log.trace("Sending docker inspect request.")
+        var head = HTTPRequestHead(
+            version: .http1_1,
+            method: .GET,
+            uri: "/containers/\(containerName)/json"
+        )
+        head.headers.add(name: "Host", value: "docker")
+        head.headers.add(name: "Accept", value: "application/json")
+        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+    }
+
+    private func sendUpgradeRequest(context: ChannelHandlerContext) {
+        Library.log.trace("Sending docker attach upgrade.")
+        var head = HTTPRequestHead(
+            version: .http1_1,
+            method: .POST,
+            uri: "/containers/\(containerName)/attach?stream=1&stdin=1&stdout=1&stderr=1"
+        )
+        head.headers.add(name: "Host", value: "docker")
+        head.headers.add(name: "Connection", value: "Upgrade")
+        head.headers.add(name: "Upgrade", value: "tcp")
+        head.headers.add(name: "Content-Length", value: "0")
+        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+    }
+
+    private func finishInspect(context: ChannelHandlerContext) {
+        let bodyBytes: [UInt8]
+        if var body = inspectBody {
+            bodyBytes = body.readBytes(length: body.readableBytes) ?? []
+        } else {
+            bodyBytes = []
+        }
+        inspectBody = nil
+
+        let inspect: ContainerInspect
+        do {
+            inspect = try JSONDecoder().decode(ContainerInspect.self, from: Data(bodyBytes))
+        } catch {
+            Library.log.error("Failed to decode docker inspect response: \(error.localizedDescription)")
+            fail(error, context: context)
+            return
+        }
+
+        guard inspect.config.openStdin || inspect.config.tty else {
+            Library.log.error("Container '\(containerName)' was not started with stdin open; cannot control this container.")
+            fail(DockerClientError.stdinUnavailable(containerName), context: context)
+            return
+        }
+
+        isTTY = inspect.config.tty
+        Library.log.debug("Container '\(containerName)' inspect: TTY=\(isTTY), OpenStdin=true")
+
+        state = .awaitingUpgradeHead
+        sendUpgradeRequest(context: context)
+    }
+
+    private func beginUpgrade(context: ChannelHandlerContext) {
+        Library.log.debug("Docker attach upgrade accepted.")
+        state = .reconfiguring
+
+        let pipeline = context.pipeline
+        let channel = context.channel
+        let encoder = self.httpEncoder
+        let decoder = self.httpDecoder
+
+        // Order matters: add the new handlers first so they're in place to receive
+        // any leftover bytes when the decoder is removed. Remove ourselves before
+        // the decoder so the forwarded raw bytes bypass us and reach the demux.
+        installPostUpgradeHandlers(channel, isTTY)
+            .flatMap { pipeline.removeHandler(encoder) }
+            .flatMap { pipeline.removeHandler(self) }
+            .flatMap { pipeline.removeHandler(decoder) }
+            .whenComplete { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success:
+                    Library.log.debug("Docker attach upgrade completed.")
+                    self.state = .streaming
+                    self.connectPromise.succeed(())
+                case .failure(let error):
+                    Library.log.error("Failed to reconfigure pipeline after upgrade: \(error.localizedDescription)")
+                    self.state = .failed
+                    self.connectPromise.fail(error)
+                    context.close(promise: nil)
+                }
+            }
+    }
+
+    private func fail(_ error: Error, context: ChannelHandlerContext) {
+        guard state != .failed, state != .streaming, state != .reconfiguring else { return }
+        state = .failed
+        connectPromise.fail(error)
+        context.close(promise: nil)
+    }
+}
+
+/// Strips Docker's 8-byte stdout/stderr framing from non-TTY attach streams,
+/// forwarding only payload bytes downstream. stdin (outbound) is never framed,
+/// so writes from later handlers pass through untouched.
+final class DockerStreamDemuxHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+
+    private static let headerSize = 8
+
+    private var pending: ByteBuffer?
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var incoming = unwrapInboundIn(data)
+        if pending == nil {
+            pending = incoming
+        } else {
+            pending?.writeBuffer(&incoming)
+        }
+        drain(context: context)
+    }
+
+    private func drain(context: ChannelHandlerContext) {
+        guard var buffer = pending else { return }
+
+        while buffer.readableBytes >= Self.headerSize {
+            let lengthOffset = buffer.readerIndex + 4
+            guard let length = buffer.getInteger(at: lengthOffset, endianness: .big, as: UInt32.self) else {
+                break
+            }
+            let frameSize = Self.headerSize + Int(length)
+            guard buffer.readableBytes >= frameSize else { break }
+
+            buffer.moveReaderIndex(forwardBy: Self.headerSize)
+            if length > 0, let payload = buffer.readSlice(length: Int(length)) {
+                context.fireChannelRead(wrapInboundOut(payload))
             }
         }
-        return nil
+
+        pending = buffer.readableBytes > 0 ? buffer : nil
     }
 }

--- a/Sources/Bedrockifier/Client/DockerClient.swift
+++ b/Sources/Bedrockifier/Client/DockerClient.swift
@@ -111,12 +111,14 @@ final class DockerClient {
             httpEncoder: httpEncoder,
             httpDecoder: httpDecoder
         ) { channel, isTTY in
+            let terminalHandler = TerminalHandler(terminal: terminal, convertNewlines: !isTTY)
+            
             if isTTY {
-                return channel.pipeline.addHandler(TerminalHandler(terminal: terminal))
+                return channel.pipeline.addHandler(terminalHandler)
             }
             return channel.pipeline.addHandlers([
                 DockerStreamDemuxHandler(),
-                TerminalHandler(terminal: terminal)
+                terminalHandler
             ])
         }
 

--- a/Sources/Bedrockifier/Client/DockerClient.swift
+++ b/Sources/Bedrockifier/Client/DockerClient.swift
@@ -36,8 +36,6 @@ enum DockerClientError: Error {
 }
 
 final class DockerClient {
-    static let defaultSocketPath = "/var/run/docker.sock"
-
     private let group: EventLoopGroup
     private let terminal: PseudoTerminal
     private let socketPath: String
@@ -53,7 +51,7 @@ final class DockerClient {
     init(
         group: EventLoopGroup,
         terminal: PseudoTerminal,
-        socketPath: String = DockerClient.defaultSocketPath,
+        socketPath: String,
         onDisconnect: (() -> Void)? = nil
     ) {
         self.group = group

--- a/Sources/Bedrockifier/Client/DockerClient.swift
+++ b/Sources/Bedrockifier/Client/DockerClient.swift
@@ -91,8 +91,8 @@ final class DockerClient {
                 channel.pipeline.addHandler(upgradeHandler)
             }
 
+        Library.log.trace("Opening docker socket...")
         let channel = try await bootstrap.connect(unixDomainSocketPath: socketPath).get()
-
         do {
             try await upgradePromise.futureResult.get()
         } catch {
@@ -100,6 +100,7 @@ final class DockerClient {
             throw error
         }
 
+        Library.log.trace("Creating channel.")
         self.connectedChannel = channel
         channel.closeFuture.whenComplete { [weak self, weak channel] _ in
             guard let self = self, let channel = channel else { return }
@@ -110,6 +111,8 @@ final class DockerClient {
             }
             Library.log.warning("Docker connection closed.")
         }
+        
+        Library.log.info("Attached to container '\(containerName)'.")
     }
 
     func close() async throws {
@@ -187,6 +190,7 @@ final class DockerAttachUpgradeHandler: ChannelInboundHandler, RemovableChannelH
     }
 
     func channelActive(context: ChannelHandlerContext) {
+        Library.log.trace("Starting docker connection upgrade.")
         let path = "/containers/\(containerName)/attach?stream=1&stdin=1&stdout=1&stderr=1"
         let request =
             "POST \(path) HTTP/1.1\r\n" +
@@ -255,7 +259,9 @@ final class DockerAttachUpgradeHandler: ChannelInboundHandler, RemovableChannelH
                 if let leftover = leftover, leftover.readableBytes > 0 {
                     context.fireChannelRead(self.wrapInboundOut(leftover))
                 }
-                context.pipeline.removeHandler(context: context).whenComplete { _ in
+                context.pipeline.removeHandler(self).whenComplete { _ in
+                    Library.log.debug("Docker attach upgrade completed.")
+                    Library.log.debug("\(context.pipeline.debugDescription)")
                     self.upgradePromise.succeed(())
                 }
             case .failure(let error):

--- a/Sources/Bedrockifier/Client/DockerClient.swift
+++ b/Sources/Bedrockifier/Client/DockerClient.swift
@@ -1,0 +1,301 @@
+/*
+ Bedrockifier
+
+ Copyright (c) 2026 Adam Thayer
+ Licensed under the MIT license, as follows:
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.)
+ */
+
+import Foundation
+
+import NIOCore
+import NIOPosix
+import PTYKit
+
+enum DockerClientError: Error {
+    case invalidResponse
+    case upgradeFailed(String)
+    case connectionClosed
+}
+
+final class DockerClient {
+    static let defaultSocketPath = "/var/run/docker.sock"
+
+    private let group: EventLoopGroup
+    private let terminal: PseudoTerminal
+    private let socketPath: String
+
+    private var connectedChannel: Channel?
+    private var attachedContainer: String?
+    private var reconnectAttemptTask: Task<Void, Never>?
+    private var isConnecting = false
+    private var reconnectState = SSHReconnectState()
+
+    private let onDisconnect: (() -> Void)?
+
+    init(
+        group: EventLoopGroup,
+        terminal: PseudoTerminal,
+        socketPath: String = DockerClient.defaultSocketPath,
+        onDisconnect: (() -> Void)? = nil
+    ) {
+        self.group = group
+        self.terminal = terminal
+        self.socketPath = socketPath
+        self.onDisconnect = onDisconnect
+    }
+
+    var isConnected: Bool {
+        return connectedChannel?.isActive == true
+    }
+
+    func connect(containerName: String) async throws {
+        guard !isConnecting else {
+            Library.log.debug("Skipping duplicate Docker connect request while a connect is already in progress.")
+            return
+        }
+
+        self.isConnecting = true
+        defer { self.isConnecting = false }
+
+        self.attachedContainer = containerName
+        Library.log.info("Connecting Docker attach for container '\(containerName)' via \(socketPath)")
+
+        let terminal = self.terminal
+        let upgradePromise = group.next().makePromise(of: Void.self)
+        let upgradeHandler = DockerAttachUpgradeHandler(
+            containerName: containerName,
+            upgradePromise: upgradePromise
+        ) { channel in
+            channel.pipeline.addHandler(TerminalHandler(terminal: terminal))
+        }
+
+        let bootstrap = ClientBootstrap(group: group)
+            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_KEEPALIVE), value: 1)
+            .channelInitializer { channel in
+                channel.pipeline.addHandler(upgradeHandler)
+            }
+
+        let channel = try await bootstrap.connect(unixDomainSocketPath: socketPath).get()
+
+        do {
+            try await upgradePromise.futureResult.get()
+        } catch {
+            try? await channel.close()
+            throw error
+        }
+
+        self.connectedChannel = channel
+        channel.closeFuture.whenComplete { [weak self, weak channel] _ in
+            guard let self = self, let channel = channel else { return }
+            let wasActiveChannel = self.connectedChannel === channel
+            if wasActiveChannel {
+                self.connectedChannel = nil
+                self.startReconnectCycleIfNeeded()
+            }
+            Library.log.warning("Docker connection closed.")
+        }
+    }
+
+    func close() async throws {
+        Library.log.trace("Closing Docker connection.")
+        self.reconnectState.beginExplicitClose()
+        defer {
+            self.reconnectState.endExplicitClose()
+            self.connectedChannel = nil
+            self.reconnectAttemptTask = nil
+        }
+
+        self.reconnectAttemptTask?.cancel()
+        self.reconnectState.reconnectCycleCompleted()
+        try await connectedChannel?.close()
+    }
+
+    private func startReconnectCycleIfNeeded() {
+        guard reconnectState.shouldStartReconnectCycle(onDisconnectFromActiveChannel: true) else {
+            return
+        }
+
+        guard reconnectAttemptTask == nil else {
+            return
+        }
+
+        guard let container = attachedContainer else {
+            reconnectState.reconnectCycleCompleted()
+            return
+        }
+
+        reconnectAttemptTask = Task { [weak self] in
+            guard let self = self else { return }
+            defer {
+                self.reconnectAttemptTask = nil
+                self.reconnectState.reconnectCycleCompleted()
+            }
+
+            self.onDisconnect?()
+
+            do {
+                Library.log.info("Detected Docker disconnect. Attempting immediate reconnect...")
+                try await self.connect(containerName: container)
+            } catch is CancellationError {
+                Library.log.debug("Reconnect attempt cancelled.")
+            } catch {
+                Library.log.warning("Immediate reconnect attempt failed: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+/// Sends the Docker attach request, parses the HTTP/1.1 response headers,
+/// validates the 101 upgrade, then swaps itself out for the supplied post-upgrade
+/// handlers so the rest of the pipeline sees a raw byte stream to the container.
+final class DockerAttachUpgradeHandler: ChannelInboundHandler, RemovableChannelHandler {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    private let containerName: String
+    private let upgradePromise: EventLoopPromise<Void>
+    private let installPostUpgradeHandlers: (Channel) -> EventLoopFuture<Void>
+
+    private var responseBuffer: ByteBuffer?
+    private var upgradeComplete = false
+
+    init(
+        containerName: String,
+        upgradePromise: EventLoopPromise<Void>,
+        installPostUpgradeHandlers: @escaping (Channel) -> EventLoopFuture<Void>
+    ) {
+        self.containerName = containerName
+        self.upgradePromise = upgradePromise
+        self.installPostUpgradeHandlers = installPostUpgradeHandlers
+    }
+
+    func channelActive(context: ChannelHandlerContext) {
+        let path = "/containers/\(containerName)/attach?stream=1&stdin=1&stdout=1&stderr=1"
+        let request =
+            "POST \(path) HTTP/1.1\r\n" +
+            "Host: docker\r\n" +
+            "Connection: Upgrade\r\n" +
+            "Upgrade: tcp\r\n" +
+            "Content-Length: 0\r\n" +
+            "\r\n"
+
+        var buffer = context.channel.allocator.buffer(capacity: request.utf8.count)
+        buffer.writeString(request)
+        context.writeAndFlush(wrapOutboundOut(buffer), promise: nil)
+        context.fireChannelActive()
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var inbound = unwrapInboundIn(data)
+
+        if upgradeComplete {
+            // Post-upgrade reads should already be flowing past us. Pass through defensively.
+            context.fireChannelRead(wrapInboundOut(inbound))
+            return
+        }
+
+        if responseBuffer == nil {
+            responseBuffer = inbound
+        } else {
+            responseBuffer?.writeBuffer(&inbound)
+        }
+
+        guard var buffer = responseBuffer else { return }
+        guard let headerEnd = indexOfCRLFCRLF(in: buffer.readableBytesView) else {
+            // Wait for more data; keep accumulating.
+            responseBuffer = buffer
+            return
+        }
+
+        let headerLength = headerEnd + 4
+        let headerBytes = buffer.readBytes(length: headerLength) ?? []
+        let leftover = buffer.readableBytes > 0 ? buffer.readSlice(length: buffer.readableBytes) : nil
+        responseBuffer = nil
+
+        guard let headers = String(bytes: headerBytes, encoding: .utf8) else {
+            upgradePromise.fail(DockerClientError.invalidResponse)
+            context.close(promise: nil)
+            return
+        }
+
+        let statusLine = headers.split(whereSeparator: { $0 == "\r" || $0 == "\n" }).first.map(String.init) ?? ""
+        let parts = statusLine.split(separator: " ", maxSplits: 2).map(String.init)
+        guard parts.count >= 2, parts[1] == "101" else {
+            Library.log.error("Docker attach upgrade failed: '\(statusLine)'")
+            upgradePromise.fail(DockerClientError.upgradeFailed(statusLine))
+            context.close(promise: nil)
+            return
+        }
+
+        Library.log.debug("Docker attach upgrade accepted.")
+        upgradeComplete = true
+
+        installPostUpgradeHandlers(context.channel).whenComplete { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success:
+                // Forward any bytes that arrived after the headers — they belong to the post-upgrade pipeline.
+                if let leftover = leftover, leftover.readableBytes > 0 {
+                    context.fireChannelRead(self.wrapInboundOut(leftover))
+                }
+                context.pipeline.removeHandler(context: context).whenComplete { _ in
+                    self.upgradePromise.succeed(())
+                }
+            case .failure(let error):
+                self.upgradePromise.fail(error)
+                context.close(promise: nil)
+            }
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        if !upgradeComplete {
+            upgradePromise.fail(error)
+        }
+        Library.log.error("Docker pipeline error: \(error.localizedDescription)")
+        context.close(promise: nil)
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        if !upgradeComplete {
+            upgradePromise.fail(DockerClientError.connectionClosed)
+        }
+        context.fireChannelInactive()
+    }
+
+    private func indexOfCRLFCRLF(in bytes: ByteBufferView) -> Int? {
+        // \r\n\r\n
+        let needle: [UInt8] = [0x0D, 0x0A, 0x0D, 0x0A]
+        guard bytes.count >= needle.count else { return nil }
+        let start = bytes.startIndex
+        for offset in 0...(bytes.count - needle.count) {
+            let i0 = bytes.index(start, offsetBy: offset)
+            if bytes[i0] == needle[0]
+                && bytes[bytes.index(i0, offsetBy: 1)] == needle[1]
+                && bytes[bytes.index(i0, offsetBy: 2)] == needle[2]
+                && bytes[bytes.index(i0, offsetBy: 3)] == needle[3] {
+                return offset
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Bedrockifier/Client/SSHClient.swift
+++ b/Sources/Bedrockifier/Client/SSHClient.swift
@@ -114,9 +114,9 @@ final class SSHClient {
     private func makeBootstrap() -> ClientBootstrap {
         return ClientBootstrap(group: group)
             .channelInitializer(self.initializeChannel)
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_KEEPALIVE), value: 1)
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
+            .channelOption(.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(.socketOption(.so_keepalive), value: 1)
+            .channelOption(.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
     }
 
     private func initializeChannel(channel: Channel) -> EventLoopFuture<Void> {

--- a/Sources/Bedrockifier/Client/SSHHandler.swift
+++ b/Sources/Bedrockifier/Client/SSHHandler.swift
@@ -66,7 +66,7 @@ final class SSHPipeHandler: ChannelDuplexHandler {
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let bytes = self.unwrapOutboundIn(data)
 
-        Library.log.trace("writing data: '\(String(buffer: bytes).withEscapedInvisibles())'")
+        Library.log.trace("writing data: '\(String(buffer: bytes).debugDescription)'")
         let channelData = SSHChannelData(type: .channel, data: .byteBuffer(bytes))
         context.write(self.wrapOutboundOut(channelData), promise: promise)
     }

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -34,11 +34,13 @@ final class TerminalHandler: ChannelDuplexHandler, @unchecked Sendable {
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 
+    private let convertNewlines: Bool
     private let terminal: PseudoTerminal
     private var terminalChannel: PseudoTerminal.Channel?
 
-    init(terminal: PseudoTerminal) {
+    init(terminal: PseudoTerminal, convertNewlines: Bool = true) {
         self.terminal = terminal
+        self.convertNewlines = convertNewlines
     }
 
     deinit {
@@ -65,7 +67,9 @@ final class TerminalHandler: ChannelDuplexHandler, @unchecked Sendable {
                         return
                     }
                     
-                    string = string.convertNewlinesForSSH()
+                    if self.convertNewlines {
+                        string = string.convertNewlinesForSSH()
+                    }
                     Library.log.trace("Read data from NIO terminal: '\(string.debugDescription)'")
                     let buffer = ByteBuffer(string: string)
                     context.writeAndFlush(self.wrapOutboundOut(buffer)).whenFailure { error in

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -67,7 +67,9 @@ final class TerminalHandler: ChannelDuplexHandler {
                     string = string.convertNewlinesForSSH()
                     Library.log.trace("Read data from NIO terminal: '\(string.debugDescription)'")
                     let buffer = ByteBuffer(string: string)
-                    context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
+                    context.writeAndFlush(self.wrapOutboundOut(buffer)).whenFailure { error in
+                        Library.log.error("Failed to write to Channel. (\(error.localizedDescription))")
+                    }
                 }
                 
                 self.terminalChannel = channel

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -56,22 +56,22 @@ final class TerminalHandler: ChannelDuplexHandler {
     func handlerAdded(context: ChannelHandlerContext) {
         Task {
             do {
-                Library.log.trace("Connecting SSH Terminal.")
+                Library.log.trace("Connecting NIO Terminal.")
                 let channel = try await terminal.connect()
                 channel.fileHandle.readabilityHandler = { handle in
                     guard var string = String(data: handle.availableData, encoding: .utf8) else {
-                        Library.log.error("Failed to read terminal data as UTF8 for SSH.")
+                        Library.log.error("Failed to read terminal data as UTF8 for NIO.")
                         return
                     }
                     
                     string = string.convertNewlinesForSSH()
-                    Library.log.trace("Read data from terminal: '\(string.withEscapedInvisibles())'")
+                    Library.log.trace("Read data from NIO terminal: '\(string.debugDescription)'")
                     let buffer = ByteBuffer(string: string)
                     context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
                 }
                 
                 self.terminalChannel = channel
-                Library.log.info("SSH terminal connected.")
+                Library.log.info("NIO terminal connected.")
             } catch {
                 Library.log.error("Failed to connect to terminal. (\(error.localizedDescription))")
             }
@@ -83,7 +83,7 @@ final class TerminalHandler: ChannelDuplexHandler {
             self.terminalChannel?.fileHandle.readabilityHandler = nil
             do {
                 try await self.terminalChannel?.disconnect()
-                Library.log.info("SSH Terminal disconnected.")
+                Library.log.info("NIO Terminal disconnected.")
             } catch {
                 Library.log.error("Failed to disconnect from Terminal. (\(error.localizedDescription)")
             }
@@ -93,11 +93,11 @@ final class TerminalHandler: ChannelDuplexHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let bytes = unwrapInboundIn(data)
         let writableData = Data(buffer: bytes, byteTransferStrategy: .noCopy)
-        Library.log.trace("writing data to terminal")
+        Library.log.trace("Writing data to NIO terminal")
         if let terminalChannel = self.terminalChannel {
             do {
                 try terminalChannel.fileHandle.write(contentsOf: writableData)
-                Library.log.trace("written data to terminal")
+                Library.log.trace("Wrote data to NIO terminal")
             } catch {
                 Library.log.error("Failed to write data to terminal fileHandle.")
             }

--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -27,7 +27,8 @@ import Foundation
 import NIOCore
 import PTYKit
 
-final class TerminalHandler: ChannelDuplexHandler {
+
+final class TerminalHandler: ChannelDuplexHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
 
     typealias OutboundIn = ByteBuffer

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -56,10 +56,8 @@ public struct BackupConfig: Codable {
         public var bedrock: [ContainerConfig]?
     }
 
-    public var dockerPath: String?
+    public var dockerSocketPath: String?
     public var rconPath: String?
-    public var sshPath: String?
-    public var sshpassPath: String?
     public var backupPath: String?
     public var tokenPath: String?
     public var listenerReconnectInterval: String?
@@ -70,6 +68,12 @@ public struct BackupConfig: Codable {
     public var ownership: OwnershipConfig?
     public var schedule: ScheduleConfig?
     public var loggingLevel: LoggingConfig?
+    
+    // Deprecated - Not Used Anymore
+    // Kept here because removal would regress existing users
+    public var dockerPath: String?
+    public var sshPath: String?
+    public var sshpassPath: String?
 }
 
 extension BackupConfig.ContainerConfig {

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -63,6 +63,45 @@ struct ProcessChannel: ContainerChannel {
     }
 }
 
+struct DockerChannel: ContainerChannel {
+    private let client: DockerClient
+    private let containerName: String
+
+    init(
+        terminal: PseudoTerminal,
+        containerName: String,
+        socketPath: String,
+    ) {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        self.client = DockerClient(group: group, terminal: terminal, socketPath: socketPath)
+        self.containerName = containerName
+    }
+    
+    var isConnected: Bool { client.isConnected }
+
+    func start() async throws {
+        do {
+            try await client.connect(containerName: containerName)
+        } catch {
+            Library.log.error("Failed to connect Docker channel to container. (\(error.localizedDescription))")
+            Library.log.error(
+                "Check that the Docker configuration is correct, and check the minecraft server logs for further errors."
+            )
+        }
+    }
+    
+    func close() async throws {
+        do {
+            try await client.close()
+        } catch {
+            Library.log.error("Failed to close Docker channel. (\(error.localizedDescription))")
+            throw error
+        }
+    }
+
+    func reset() {}
+}
+
 struct SecureShellChannel: ContainerChannel {
     private let host: String
     private let port: Int

--- a/Sources/Bedrockifier/Model/ContainerConfig.swift
+++ b/Sources/Bedrockifier/Model/ContainerConfig.swift
@@ -28,12 +28,12 @@ import Foundation
 import PTYKit
 
 public struct ToolConfig {
-    let dockerPath: String
+    let dockerSocketPath: String
     let rconPath: String
     let hostKeyValidator: SSHHostKeyValidator
 
-    public init(dockerPath: String, rconPath: String, hostKeyValidator: SSHHostKeyValidator) {
-        self.dockerPath = dockerPath
+    public init(dockerSocketPath: String, rconPath: String, hostKeyValidator: SSHHostKeyValidator) {
+        self.dockerSocketPath = dockerSocketPath
         self.rconPath = rconPath
         self.hostKeyValidator = hostKeyValidator
     }
@@ -74,49 +74,48 @@ public enum ContainerConnectionConfigKind {
     case ssh
 }
 
+public enum ContainerChannelConfig {
+    case process(url: URL, arguments: [String])
+    case ssh(host: String, port: Int, validator: SSHHostKeyValidator)
+    case docker(socket: String, container: String)
+}
+
 public protocol ContainerConnectionConfig {
     var prefixContainerName: Bool { get }
-    var processPath: String { get }
     var kind: ContainerConnectionConfigKind { get }
     var newline: TerminalNewline { get }
     var password: ContainerPassword { get }
-    var validator: SSHHostKeyValidator? { get }
-    func makeArguments() throws -> [String]
+    func makeChannelConfig() throws -> ContainerChannelConfig
 }
 
 extension ContainerConnectionConfig {
-    var processUrl: URL { URL(fileURLWithPath: processPath) }
+    //var processUrl: URL { URL(fileURLWithPath: processPath) }
 }
 
 public struct DockerConnectionConfig: ContainerConnectionConfig {
-    let dockerPath: String
+    let socketPath: String
     let containerName: String
     public let password: ContainerPassword = .none
     public let validator: SSHHostKeyValidator? = nil
     public let prefixContainerName: Bool
-
-    init(dockerPath: String, config: BackupConfig.ContainerConfig, prefixAllContainerNames: Bool) {
-        self.dockerPath = dockerPath
+    
+    init(socketPath: String, config: BackupConfig.ContainerConfig, prefixAllContainerNames: Bool) {
+        self.socketPath = socketPath
         self.containerName = config.name
         self.prefixContainerName = config.prefixContainerName == true || prefixAllContainerNames
     }
 
-    init(dockerPath: String, containerName: String, prefixAllContainerNames: Bool) {
-        self.dockerPath = dockerPath
+    init(socketPath: String, containerName: String, prefixAllContainerNames: Bool) {
+        self.socketPath = socketPath
         self.containerName = containerName
         self.prefixContainerName = prefixAllContainerNames
     }
 
     public var kind: ContainerConnectionConfigKind { .docker }
     public var newline: TerminalNewline { .default }
-    public var processPath: String { dockerPath }
-
-    public func makeArguments() -> [String] {
-        return [
-            "attach",
-            "--sig-proxy=false",
-            containerName
-        ]
+    
+    public func makeChannelConfig() throws -> ContainerChannelConfig {
+        return .docker(socket: socketPath, container: containerName)
     }
 }
 
@@ -145,22 +144,23 @@ public struct RCONConnectionConfig: ContainerConnectionConfig {
 
     public var kind: ContainerConnectionConfigKind { .rcon }
     public var newline: TerminalNewline { .ssh }
-    public var processPath: String { rconPath }
-
-    public func makeArguments() throws -> [String] {
+    
+    public func makeChannelConfig() throws -> ContainerChannelConfig {
         let parts = address.split(whereSeparator: { $0 == ":" })
         guard parts.count == 2 else {
             throw ParseError.invalidHostname(address)
         }
-
-        return [
-            "--host",
-            "\(parts[0])",
-            "--port",
-            "\(parts[1])",
-            "--password",
-            "\(password)"
-        ]
+        
+        return .process(
+            url: URL(fileURLWithPath: rconPath),
+            arguments: [
+                "--host",
+                "\(parts[0])",
+                "--port",
+                "\(parts[1])",
+                "--password",
+                "\(password)"
+        ])
     }
 }
 
@@ -188,17 +188,19 @@ public struct SSHConnectionConfig: ContainerConnectionConfig {
 
     public var kind: ContainerConnectionConfigKind { .ssh }
     public var newline: TerminalNewline { .ssh }
-    public var processPath: String { "" }
-
-    public func makeArguments() throws -> [String] {
+    
+    public func makeChannelConfig() throws -> ContainerChannelConfig {
         let parts = address.split(whereSeparator: { $0 == ":" })
         guard parts.count == 2 else {
             throw ParseError.invalidHostname(address)
         }
-
-        return [
-            String(parts[0]),
-            String(parts[1])
-        ]
+        guard let port = Int(parts[1]) else {
+            throw ParseError.invalidHostname(address)
+        }
+        guard let validator else {
+            throw ParseError.invalidSyntax
+        }
+        
+        return .ssh(host: String(parts[0]), port: port, validator: validator)
     }
 }

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -73,31 +73,20 @@ public class ContainerConnection {
         case .java:
             self.terminal = JavaTerminal(terminal: terminal)
         }
-
-        switch connectionConfig.kind {
-        case .ssh:
-            let address = try connectionConfig.makeArguments()
-            guard let port = Int(address[1]) else {
-                throw ParseError.invalidSyntax
-            }
-            guard let validator = config.validator else {
-                throw ParseError.invalidSyntax
-            }
+        
+        switch try connectionConfig.makeChannelConfig() {
+        case .process(let url, let arguments):
+            self.channel = try await ProcessChannel(terminal: terminal, processUrl: url, processArgs: arguments)
+        case .docker(let socketPath, let containerName):
+            self.channel = DockerChannel(terminal: terminal, containerName: containerName, socketPath: socketPath)
+        case .ssh(let host, let port, let validator):
             self.channel = SecureShellChannel(
                 terminal: terminal,
-                host: address[0],
+                host: host,
                 port: port,
                 validator: validator,
                 password: connectionConfig.password
             )
-        case .rcon:
-            let processUrl = config.processUrl
-            let processArgs = try config.makeArguments()
-            self.channel = try await ProcessChannel(terminal: terminal, processUrl: processUrl, processArgs: processArgs)
-        case .docker:
-            let processUrl = config.processUrl
-            let processArgs = try config.makeArguments()
-            self.channel = try await ProcessChannel(terminal: terminal, processUrl: processUrl, processArgs: processArgs)
         }
 
         try await self.terminal.setWindowSize(columns: 65000, rows: 24)
@@ -355,7 +344,7 @@ extension ContainerConnection {
             let worlds = try World.getWorlds(at: worldsFolder)
             let worldPaths = worlds.map({ $0.location.path })
             let config = DockerConnectionConfig(
-                dockerPath: tools.dockerPath,
+                socketPath: tools.dockerSocketPath,
                 containerName: containerName,
                 prefixAllContainerNames: prefixAllContainers
             )
@@ -392,7 +381,7 @@ extension ContainerConnection {
             return rconConfig
         } else {
             return DockerConnectionConfig(
-                dockerPath: tools.dockerPath,
+                socketPath: tools.dockerSocketPath,
                 config: container,
                 prefixAllContainerNames: prefixAllContainerNames
             )

--- a/Sources/Bedrockifier/Utilities/StringUtils.swift
+++ b/Sources/Bedrockifier/Utilities/StringUtils.swift
@@ -26,12 +26,6 @@
 import Foundation
 
 extension String {
-    func withEscapedInvisibles() -> String {
-        self
-            .replacingOccurrences(of: "\r", with: "\\r")
-            .replacingOccurrences(of: "\n", with: "\\n")
-    }
-
     func convertNewlinesForSSH() -> String {
         self.replacingOccurrences(of: "\n", with: "\r\n")
     }

--- a/Sources/Service/EnvironmentConfig.swift
+++ b/Sources/Service/EnvironmentConfig.swift
@@ -36,7 +36,7 @@ struct EnvironmentConfig {
     static let defaultOldDataPath = "/backups"
 
     // External Tools in Container
-    let dockerPath: String
+    let dockerSocketPath: String
     let rconPath: String
 
     // Config Folder Settings
@@ -53,7 +53,7 @@ struct EnvironmentConfig {
 
     init() {
         // External Tools in Container
-        self.dockerPath = ProcessInfo.processInfo.environment["DOCKER_PATH"] ?? "/usr/bin/docker"
+        self.dockerSocketPath = ProcessInfo.processInfo.environment["DOCKER_SOCK"] ?? "/var/run/docker.sock"
         self.rconPath = ProcessInfo.processInfo.environment["RCON_PATH"] ?? "/usr/local/bin/rcon-cli"
 
         // Config Folder Settings

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -24,7 +24,6 @@
  */
 
 import ArgumentParser
-import Backtrace
 import Foundation
 import Logging
 import PTYKit

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -41,7 +41,7 @@ struct Server: ParsableCommand {
     var hostKeysPath: String?
 
     @Option(name: .shortAndLong, help: "Path to docker")
-    var dockerPath: String?
+    var dockerSocketPath: String?
 
     @Option(name: .shortAndLong, help: "Path to rcon-cli")
     var rconPath: String?
@@ -79,10 +79,9 @@ struct Server: ParsableCommand {
             return
         }
 
-        let dockerPath = self.dockerPath ?? config.dockerPath ?? environment.dockerPath
-        guard FileManager.default.fileExists(atPath: dockerPath) else {
-            Server.logger.error("Docker not found at path \(dockerPath)")
-            return
+        let dockerSocketPath = self.dockerSocketPath ?? config.dockerSocketPath ?? environment.dockerSocketPath
+        if !FileManager.default.fileExists(atPath: dockerSocketPath) {
+            Server.logger.info("Docker socket not found at path \(dockerSocketPath). Using docker to control containers will fail.")
         }
 
         let rconPath = self.rconPath ?? config.rconPath ?? environment.rconPath
@@ -93,7 +92,7 @@ struct Server: ParsableCommand {
 
         let hostKeysUri = getHostKeyFileUrl(environment: environment)
         let tools = ToolConfig(
-            dockerPath: dockerPath,
+            dockerSocketPath: dockerSocketPath,
             rconPath: rconPath,
             hostKeyValidator: SSHHostKeyValidator(keysFile: hostKeysUri)
         )


### PR DESCRIPTION
Instead of creating a docker cli process and attaching to it, this will connect to the socket directly using swift-nio, and then upgrading the HTTP connection to the stream needed to communicate with the other container. So now it just needs access to the docker socket. 

In principle, this could be the basis for two further changes:
1. Enable use of a docker socket proxy, which is more secure than direct access to the socket, as the proxy can then be use to only allow attach access to specific containers. Need to add support for detecting `tcp://host:2375` style connections to do that.
2. Allow similar behavior for Kubernetes if desired.

Closes #171