### PR TITLE
Upgrade With Latest PTYKit Logic

### DIFF
--- a/Sources/Bedrockifier/Client/TerminalHandler.swift
+++ b/Sources/Bedrockifier/Client/TerminalHandler.swift
@@ -41,17 +41,21 @@ final class TerminalHandler: ChannelDuplexHandler {
     }
 
     deinit {
-        do {
-            try terminalChannel?.disconnect()
-            Library.log.info("SSH Terminal disconnected from deinit.")
-        } catch {
-            Library.log.error("Failed to disconnect from Terminal during deinit. (\(error.localizedDescription)")
+        if let terminalChannel {
+            Task {
+                do {
+                    try await terminalChannel.disconnect()
+                    Library.log.info("SSH Terminal disconnected from deinit.")
+                } catch {
+                    Library.log.error("Failed to disconnect from Terminal during deinit. (\(error.localizedDescription)")
+                }
+            }
         }
     }
 
-    func handlerAdded(context: ChannelHandlerContext) {
+    func handlerAdded(context: ChannelHandlerContext) async {
         do {
-            let channel = try terminal.connect()
+            let channel = try await terminal.connect()
             channel.fileHandle.readabilityHandler = { handle in
                 guard var string = String(data: handle.availableData, encoding: .utf8) else {
                     Library.log.error("Failed to read terminal data as UTF8 for SSH.")
@@ -71,10 +75,10 @@ final class TerminalHandler: ChannelDuplexHandler {
         }
     }
 
-    func handlerRemoved(context: ChannelHandlerContext) {
+    func handlerRemoved(context: ChannelHandlerContext) async {
         self.terminalChannel?.fileHandle.readabilityHandler = nil
         do {
-            try self.terminalChannel?.disconnect()
+            try await self.terminalChannel?.disconnect()
             Library.log.info("SSH Terminal disconnected.")
         } catch {
             Library.log.error("Failed to disconnect from Terminal. (\(error.localizedDescription)")

--- a/Sources/Bedrockifier/Model/ContainerChannel.swift
+++ b/Sources/Bedrockifier/Model/ContainerChannel.swift
@@ -32,7 +32,7 @@ protocol ContainerChannel {
 
     func start() async throws
     func close() async throws
-    mutating func reset() throws
+    mutating func reset() async throws
 }
 
 struct ProcessChannel: ContainerChannel {
@@ -41,11 +41,11 @@ struct ProcessChannel: ContainerChannel {
     private let processArgs: [String]
     private var process: Process
 
-    init(terminal: PseudoTerminal, processUrl: URL, processArgs: [String]) throws {
+    init(terminal: PseudoTerminal, processUrl: URL, processArgs: [String]) async throws {
         self.terminal = terminal
         self.processUrl = processUrl
         self.processArgs = processArgs
-        self.process = try Process(processUrl, arguments: processArgs, terminal: terminal)
+        self.process = try await Process(processUrl, arguments: processArgs, terminal: terminal)
     }
 
     var isConnected: Bool { process.isRunning }
@@ -58,8 +58,8 @@ struct ProcessChannel: ContainerChannel {
         try self.process.run()
     }
 
-    mutating func reset() throws {
-        self.process = try Process(processUrl, arguments: processArgs, terminal: terminal)
+    mutating func reset() async throws {
+        self.process = try await Process(processUrl, arguments: processArgs, terminal: terminal)
     }
 }
 

--- a/Sources/Bedrockifier/Model/ContainerConnection.swift
+++ b/Sources/Bedrockifier/Model/ContainerConnection.swift
@@ -58,7 +58,7 @@ public class ContainerConnection {
                 config: ContainerConnectionConfig,
                 kind: Kind,
                 worlds: [String],
-                extras: [String]?) throws {
+                extras: [String]?) async throws {
         self.name = containerName
         self.connectionConfig = config
         self.kind = kind
@@ -93,14 +93,14 @@ public class ContainerConnection {
         case .rcon:
             let processUrl = config.processUrl
             let processArgs = try config.makeArguments()
-            self.channel = try ProcessChannel(terminal: terminal, processUrl: processUrl, processArgs: processArgs)
+            self.channel = try await ProcessChannel(terminal: terminal, processUrl: processUrl, processArgs: processArgs)
         case .docker:
             let processUrl = config.processUrl
             let processArgs = try config.makeArguments()
-            self.channel = try ProcessChannel(terminal: terminal, processUrl: processUrl, processArgs: processArgs)
+            self.channel = try await ProcessChannel(terminal: terminal, processUrl: processUrl, processArgs: processArgs)
         }
 
-        try self.terminal.setWindowSize(columns: 65000, rows: 24)
+        try await self.terminal.setWindowSize(columns: 65000, rows: 24)
     }
 
     public convenience init(
@@ -109,10 +109,10 @@ public class ContainerConnection {
         kind: Kind,
         worlds: [String],
         extras: [String]?
-    ) throws {
+    ) async throws {
         Library.log.info("Starting Container Connection. newline = \(config.newline)")
         let terminal = try PseudoTerminal(identifier: containerName, newline: config.newline)
-        try self.init(terminal: terminal,
+        try await self.init(terminal: terminal,
                       containerName: containerName,
                       config: config,
                       kind: kind,
@@ -121,7 +121,9 @@ public class ContainerConnection {
     }
 
     public func listen(for strings: [String], handler: @escaping TerminalListener) {
-        terminal.terminal.listen(for: strings, handler: handler)
+        Task {
+            await terminal.terminal.listen(for: strings, handler: handler)
+        }
     }
 
     public func start() async throws {
@@ -148,9 +150,9 @@ public class ContainerConnection {
         }
     }
 
-    public func reset() throws {
+    public func reset() async throws {
         Library.log.debug("Resetting Container Process. (container: \(name), kind: \(connectionConfig.kind))")
-        try channel.reset()
+        try await channel.reset()
     }
 
     public func cleanupIncompleteBackup(destination: URL) async throws {
@@ -302,40 +304,46 @@ public class ContainerConnection {
     }
 
     private func logTerminalSize() {
-        do {
-            let windowSize = try terminal.terminal.getWindowSize()
-            Library.log.debug(
-                "Docker Process Window Size Fetched. (cols = \(windowSize.ws_col), rows = \(windowSize.ws_row)"
-            )
-        } catch {
-            Library.log.debug("Failed to get terminal window size")
+        Task {
+            do {
+                let windowSize = try await terminal.terminal.getWindowSize()
+                Library.log.debug(
+                    "Docker Process Window Size Fetched. (cols = \(windowSize.ws_col), rows = \(windowSize.ws_row)"
+                )
+            } catch {
+                Library.log.debug("Failed to get terminal window size")
+            }
         }
     }
 }
 
 extension ContainerConnection {
-    public static func loadContainers(from config: BackupConfig, tools: ToolConfig) throws -> [ContainerConnection] {
+    public static func loadContainers(from config: BackupConfig, tools: ToolConfig) async throws -> [ContainerConnection] {
         let prefixAllContainerNames = config.prefixContainerName ?? false
         var containers: [ContainerConnection] = []
         for container in config.containers?.bedrock ?? [] {
             Library.log.debug("Creating Bedrock Container Connection. (container: \(container.name))")
             let config = containerConfig(container: container, tools: tools, prefixAllContainerNames: prefixAllContainerNames)
-            let connection = try ContainerConnection(containerName: container.name,
-                                                     config: config,
-                                                     kind: .bedrock,
-                                                     worlds: container.worlds,
-                                                     extras: container.extras)
+            let connection = try await ContainerConnection(
+                containerName: container.name,
+                config: config,
+                kind: .bedrock,
+                worlds: container.worlds,
+                extras: container.extras
+            )
             containers.append(connection)
         }
 
         for container in config.containers?.java ?? [] {
             Library.log.debug("Creating Java Container Connection. (container: \(container.name)")
             let config = containerConfig(container: container, tools: tools, prefixAllContainerNames: prefixAllContainerNames)
-            let connection = try ContainerConnection(containerName: container.name,
-                                                     config: config,
-                                                     kind: .java,
-                                                     worlds: container.worlds,
-                                                     extras: container.extras)
+            let connection = try await ContainerConnection(
+                containerName: container.name,
+                config: config,
+                kind: .java,
+                worlds: container.worlds,
+                extras: container.extras
+            )
             containers.append(connection)
         }
 
@@ -352,11 +360,13 @@ extension ContainerConnection {
                 prefixAllContainerNames: prefixAllContainers
             )
 
-            let connection = try ContainerConnection(containerName: containerName,
-                                                     config: config,
-                                                     kind: .bedrock,
-                                                     worlds: worldPaths,
-                                                     extras: nil)
+            let connection = try await ContainerConnection(
+                containerName: containerName,
+                config: config,
+                kind: .bedrock,
+                worlds: worldPaths,
+                extras: nil
+            )
             containers.append(connection)
         }
 

--- a/Sources/Bedrockifier/Model/ContainerTerminal.swift
+++ b/Sources/Bedrockifier/Model/ContainerTerminal.swift
@@ -43,8 +43,8 @@ private struct ErrorStrings {
 }
 
 internal extension ContainerTerminal {
-    func setWindowSize(columns: UInt16, rows: UInt16) throws {
-        return try terminal.setWindowSize(columns: columns, rows: rows)
+    func setWindowSize(columns: UInt16, rows: UInt16) async throws {
+        return try await terminal.setWindowSize(columns: columns, rows: rows)
     }
 }
 
@@ -71,7 +71,7 @@ struct BedrockTerminal: ContainerTerminal {
 
     func resumeAutosave() async throws {
         // Release Save Hold
-        try terminal.sendLine("save resume")
+        try await terminal.sendLine("save resume")
         let saveResumeStrings = [
             "Changes to the level are resumed", // 1.17 and earlier
             "Changes to the world are resumed", // 1.18 and later
@@ -84,14 +84,14 @@ struct BedrockTerminal: ContainerTerminal {
 
     func pauseAutosave() async throws {
         // Start Save Hold
-        try terminal.sendLine("save hold")
+        try await terminal.sendLine("save hold")
         if try await expect(["Saving", "The command is already running"], timeout: 10.0) == .noMatch {
             throw ContainerConnection.ContainerError.pauseFailed
         }
 
         // Wait for files to be ready
         let saveReady = try await retrySaveQuery {
-            try terminal.sendLine("save query")
+            try await terminal.sendLine("save query")
             return try await expect(["Files are now ready to be copied"], timeout: 10.0) != .noMatch
         }
 
@@ -106,19 +106,19 @@ struct JavaTerminal: ContainerTerminal {
 
     func pauseAutosave() async throws {
         // Need a longer timeout on the flush in case server is still starting up
-        try terminal.sendLine("save-all flush")
+        try await terminal.sendLine("save-all flush")
         if try await expect(["Saved the game"], timeout: 30.0) == .noMatch {
             throw ContainerConnection.ContainerError.pauseFailed
         }
 
-        try terminal.sendLine("save-off")
+        try await terminal.sendLine("save-off")
         if try await expect(["Automatic saving is now disabled"], timeout: 10.0) == .noMatch {
             throw ContainerConnection.ContainerError.pauseFailed
         }
     }
 
     func resumeAutosave() async throws {
-        try terminal.sendLine("save-on")
+        try await terminal.sendLine("save-on")
         let saveResumeStrings = [
             "Automatic saving is now enabled",
             "Saving is already turned on"

--- a/Sources/Service/BackupActor.swift
+++ b/Sources/Service/BackupActor.swift
@@ -235,7 +235,7 @@ actor BackupActor {
             do {
                 if !needsListeners {
                     try await container.stop()
-                    try container.reset()
+                    try await container.reset()
                 }
             } catch let error {
                 failedContainers += 1

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -212,7 +212,7 @@ final class BackupService {
     }
 
     private func connectContainers() async throws {
-        let containers = try ContainerConnection.loadContainers(from: config, tools: tools)
+        let containers = try await ContainerConnection.loadContainers(from: config, tools: tools)
 
         // Attach to the containers
         if await backupActor.needsListeners() {


### PR DESCRIPTION
One reason we can get weird crashes like #107 is that PTYKit uses a final class, rather than an actor for data isolation. This means accessing things like the list of expectations can _sometimes_ hit the situation where there's a race condition which is hard to trace down. 

PTYKit was updated so that the PseudoTerminal is now an actor, rather than a class, which should block out a lot of these sort of issues. This PR makes Bedrockifier build against the actor. 