### PR TITLE
Feature/security fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,9 @@ let package = Package(
             ]),
         .testTarget(
             name: "BedrockifierTests",
-            dependencies: ["Bedrockifier"]),
+            dependencies: [
+                "Bedrockifier",
+                .product(name: "ZIPFoundation", package: "ZIPFoundation")
+            ]),
     ]
 )

--- a/Sources/Bedrockifier/Foundation/Platform.swift
+++ b/Sources/Bedrockifier/Foundation/Platform.swift
@@ -70,6 +70,28 @@ struct Platform {
             }
         })
     }
+
+    static func timingsafeCompare(_ a: String, _ b: String) -> Bool {
+        return timingsafeCompare(Array(a.utf8), Array(b.utf8))
+    }
+
+    static func timingsafeCompare(_ a: [UInt8], _ b: [UInt8]) -> Bool {
+        guard a.count == b.count else { return false }
+        return a.withUnsafeBytes { ap in
+            b.withUnsafeBytes { bp in
+                #if canImport(Darwin) || canImport(Musl)
+                return timingsafe_bcmp(ap.baseAddress, bp.baseAddress, a.count) == 0
+                #else
+                // glibc < 2.37 does not provide timingsafe_bcmp
+                var result: UInt8 = 0
+                let ab = ap.bindMemory(to: UInt8.self)
+                let bb = bp.bindMemory(to: UInt8.self)
+                for i in 0..<a.count { result |= ab[i] ^ bb[i] }
+                return result == 0
+                #endif
+            }
+        }
+    }
 }
 
 extension Platform {

--- a/Sources/Bedrockifier/Foundation/Platform.swift
+++ b/Sources/Bedrockifier/Foundation/Platform.swift
@@ -76,7 +76,7 @@ struct Platform {
     }
 
     static func timingsafeCompare(_ lhs: [UInt8], _ rhs: [UInt8]) -> Bool {
-        guard lhs.count == brhscount else { return false }
+        guard lhs.count == rhs.count else { return false }
         return lhs.withUnsafeBytes { lhsPtr in
             rhs.withUnsafeBytes { rhsPtr in
                 #if canImport(Darwin) || canImport(Musl)

--- a/Sources/Bedrockifier/Foundation/Platform.swift
+++ b/Sources/Bedrockifier/Foundation/Platform.swift
@@ -43,13 +43,13 @@ struct Platform {
     typealias UserID = __uid_t
     typealias GroupID = __gid_t
     #endif
-    
+
     static func currentUmask() -> Mode {
         let currentUmask = umask(0)
         umask(currentUmask)
         return currentUmask
     }
-    
+
     static func changeOwner(path: String, uid: UserID?, gid: GroupID?) throws {
         let realUid = uid ?? UInt32.max
         let realGid = gid ?? UInt32.max
@@ -71,22 +71,22 @@ struct Platform {
         })
     }
 
-    static func timingsafeCompare(_ a: String, _ b: String) -> Bool {
-        return timingsafeCompare(Array(a.utf8), Array(b.utf8))
+    static func timingsafeCompare(_ lhs: String, _ rhs: String) -> Bool {
+        return timingsafeCompare(Array(lhs.utf8), Array(rhs.utf8))
     }
 
-    static func timingsafeCompare(_ a: [UInt8], _ b: [UInt8]) -> Bool {
-        guard a.count == b.count else { return false }
-        return a.withUnsafeBytes { ap in
-            b.withUnsafeBytes { bp in
+    static func timingsafeCompare(_ lhs: [UInt8], _ rhs: [UInt8]) -> Bool {
+        guard lhs.count == brhscount else { return false }
+        return lhs.withUnsafeBytes { lhsPtr in
+            rhs.withUnsafeBytes { rhsPtr in
                 #if canImport(Darwin) || canImport(Musl)
-                return timingsafe_bcmp(ap.baseAddress, bp.baseAddress, a.count) == 0
+                return timingsafe_bcmp(lhsPtr.baseAddress, rhsPtr.baseAddress, lhs.count) == 0
                 #else
                 // glibc < 2.37 does not provide timingsafe_bcmp
                 var result: UInt8 = 0
-                let ab = ap.bindMemory(to: UInt8.self)
-                let bb = bp.bindMemory(to: UInt8.self)
-                for i in 0..<a.count { result |= ab[i] ^ bb[i] }
+                let lhsBind = lhsPtr.bindMemory(to: UInt8.self)
+                let rhsBind = rhsPtr.bindMemory(to: UInt8.self)
+                for index in 0..<lhs.count { result |= lhsBind[index] ^ rhsBind[index] }
                 return result == 0
                 #endif
             }

--- a/Sources/Bedrockifier/Model/World.swift
+++ b/Sources/Bedrockifier/Model/World.swift
@@ -108,6 +108,15 @@ public struct World {
         return location.lastPathComponent
     }
 
+    private static func backupNameIsSanitary(_ name: String) -> Bool {
+        let restrictedCharacters = CharacterSet(charactersIn: "\\/:*?\"<>|")
+
+        return
+            !name.isEmpty &&
+            name.rangeOfCharacter(from: restrictedCharacters) == nil &&
+            !name.contains("..")
+    }
+
     private static func fetchBedrockBackupName(location: URL) throws -> String {
         let archive = try Archive(url: location, accessMode: .read)
         guard let levelnameEntry = archive["levelname.txt"] else {
@@ -119,6 +128,10 @@ public struct World {
 
         guard let finalResult = result else {
             throw WorldError.missingLevelName
+        }
+
+        guard backupNameIsSanitary(finalResult) else {
+            throw WorldError.invalidLevelName
         }
 
         return finalResult
@@ -133,6 +146,11 @@ public struct World {
         guard let worldName = NSString(string: levelDat.path).pathComponents.first else {
             throw WorldError.missingLevelName
         }
+
+        guard backupNameIsSanitary(worldName) else {
+            throw WorldError.invalidLevelName
+        }
+
 
         return worldName
     }
@@ -311,11 +329,11 @@ extension World {
 
         return false
     }
-    
+
     func applyOwnership(owner: Platform.UserID?, group: Platform.GroupID?, permissions: Platform.Mode?) throws {
         try applyOwnership(owner: owner, group: group, folderMode: permissions, fileMode: permissions)
     }
-    
+
     func applyOwnership(owner: Platform.UserID?, group: Platform.GroupID?, folderMode: Platform.Mode?, fileMode: Platform.Mode?) throws {
         let path = self.location.path
         do {
@@ -403,6 +421,7 @@ extension World {
         case invalidUrl(url: URL, innerError: Error)
         case invalidLevelArchive
         case missingLevelName
+        case invalidLevelName
         case invalidLevelNameFile
         case archiveCreationFailed
         case failedToApplyOwnership(url: URL, error: Error)
@@ -418,6 +437,7 @@ extension World.WorldError: LocalizedError {
         case .invalidUrl(let url, let innerError): return "Unable to access world path at '\(url.path)': \(innerError)"
         case .invalidLevelArchive: return "World archive is not a valid zip or mcworld file"
         case .missingLevelName: return "Unable to determine name of the world"
+        case .invalidLevelName: return "Level name contains prohibited strings"
         case .invalidLevelNameFile: return "Unable to read contents of levelname.txt"
         case .archiveCreationFailed: return "Failed to create file for archive"
         case .failedToApplyOwnership(let url, let innerError): return "Unable to apply ownership to file at '\(url.path)': \(innerError)"

--- a/Sources/Bedrockifier/Service/TokenCheckingMiddleware.swift
+++ b/Sources/Bedrockifier/Service/TokenCheckingMiddleware.swift
@@ -60,12 +60,12 @@ struct TokenCheckingMiddleware<Context>: RouterMiddleware {
             throw HTTPError(.internalServerError, message: "Cannot accept requests at this time.")
         }
 
-        guard let token = request.headers[.authorization], token == "Bearer \(currentToken)" else {
+        guard let token = request.headers[.authorization],
+              Platform.timingsafeCompare(token, "Bearer \(currentToken)")
+        else {
             throw HTTPError(.badRequest, message: "Invalid authorization.")
         }
 
         return try await next(request, context)
     }
-
-
 }

--- a/Tests/BedrockifierTests/PlatformTests.swift
+++ b/Tests/BedrockifierTests/PlatformTests.swift
@@ -1,0 +1,70 @@
+import Testing
+@testable import Bedrockifier
+
+@Suite struct PlatformTimingsafeCompareTests {
+
+    // MARK: - String overload
+
+    @Test func equalStringsReturnsTrue() {
+        #expect(Platform.timingsafeCompare("hello", "hello"))
+    }
+
+    @Test func differentStringsReturnsFalse() {
+        #expect(!Platform.timingsafeCompare("hello", "world"))
+    }
+
+    @Test func differentLengthsReturnsFalse() {
+        #expect(!Platform.timingsafeCompare("short", "longer string"))
+    }
+
+    @Test func emptyStringsReturnTrue() {
+        #expect(Platform.timingsafeCompare("", ""))
+    }
+
+    @Test func emptyVsNonEmptyReturnsFalse() {
+        #expect(!Platform.timingsafeCompare("", "a"))
+        #expect(!Platform.timingsafeCompare("a", ""))
+    }
+
+    @Test func samePrefixDifferentSuffixReturnsFalse() {
+        #expect(!Platform.timingsafeCompare("Bearer abc123x", "Bearer abc123y"))
+    }
+
+    @Test func differentByOneByteReturnsFalse() {
+        #expect(!Platform.timingsafeCompare("aaaaaaaaa", "aaaaaaaab"))
+    }
+
+    // Mirrors the exact call pattern used in TokenCheckingMiddleware.
+    @Test func bearerTokenFormat() {
+        let token = "dGVzdHRva2VuMTIzNDU2Nzg="
+        #expect(Platform.timingsafeCompare("Bearer \(token)", "Bearer \(token)"))
+        #expect(!Platform.timingsafeCompare("Bearer wrongtoken====", "Bearer \(token)"))
+        #expect(!Platform.timingsafeCompare("Basic \(token)", "Bearer \(token)"))
+    }
+
+    // MARK: - [UInt8] overload
+
+    @Test func equalByteArraysReturnsTrue() {
+        #expect(Platform.timingsafeCompare([0x01, 0x02, 0x03], [0x01, 0x02, 0x03]))
+    }
+
+    @Test func differentByteArraysReturnsFalse() {
+        #expect(!Platform.timingsafeCompare([0x01, 0x02, 0x03], [0x01, 0x02, 0x04]))
+    }
+
+    @Test func differentLengthByteArraysReturnsFalse() {
+        #expect(!Platform.timingsafeCompare([0x01, 0x02], [0x01, 0x02, 0x03]))
+    }
+
+    @Test func emptyByteArraysReturnTrue() {
+        #expect(Platform.timingsafeCompare([], []))
+    }
+
+    @Test func firstByteDiffersReturnsFalse() {
+        #expect(!Platform.timingsafeCompare([0xFF, 0x00, 0x00], [0x00, 0x00, 0x00]))
+    }
+
+    @Test func lastByteDiffersReturnsFalse() {
+        #expect(!Platform.timingsafeCompare([0x00, 0x00, 0xFF], [0x00, 0x00, 0x00]))
+    }
+}

--- a/Tests/BedrockifierTests/WorldTests.swift
+++ b/Tests/BedrockifierTests/WorldTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import ZIPFoundation
 @testable import Bedrockifier
 
 fileprivate func makeTempDir() throws -> URL {
@@ -7,7 +8,33 @@ fileprivate func makeTempDir() throws -> URL {
     return tempDirectory
 }
 
+// Creates a .mcworld archive whose levelname.txt contains the given string.
+fileprivate func makeBedrockArchive(levelName: String) throws -> (tempDir: URL, archive: URL) {
+    let tempDir = try makeTempDir()
+    let levelNameFile = tempDir.appendingPathComponent("levelname.txt")
+    try (levelName.data(using: .utf8) ?? Data()).write(to: levelNameFile)
+
+    let archiveURL = tempDir.appendingPathComponent("test.mcworld")
+    let archive = try Archive(url: archiveURL, accessMode: .create)
+    try archive.addEntry(with: "levelname.txt", fileURL: levelNameFile)
+    return (tempDir, archiveURL)
+}
+
+// Creates a .zip archive with a single level.dat entry at the given path inside the ZIP.
+fileprivate func makeJavaArchive(levelDatPath: String) throws -> (tempDir: URL, archive: URL) {
+    let tempDir = try makeTempDir()
+    let levelDatFile = tempDir.appendingPathComponent("level.dat")
+    try Data([0]).write(to: levelDatFile)
+
+    let archiveURL = tempDir.appendingPathComponent("test.zip")
+    let archive = try Archive(url: archiveURL, accessMode: .create)
+    try archive.addEntry(with: levelDatPath, fileURL: levelDatFile)
+    return (tempDir, archiveURL)
+}
+
 final class WorldTests: XCTestCase {
+    
+    
     func testInvalidUrl() {
         let homePath = "\"\(FileManager.default.homeDirectoryForCurrentUser.path)\""
         let homeUrl = URL(fileURLWithPath: homePath)
@@ -74,6 +101,100 @@ final class WorldTests: XCTestCase {
             XCTFail("\(error.localizedDescription)")
         }
     }
+
+    // MARK: - Path Traversal (Bedrock .mcworld)
+
+    func testBedrockBackupValidName() throws {
+        let (tempDir, archiveURL) = try makeBedrockArchive(levelName: "My World")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let world = try World(url: archiveURL)
+        XCTAssertEqual(world.name, "My World")
+    }
+
+    func testBedrockBackupDotDotName() throws {
+        let (tempDir, archiveURL) = try makeBedrockArchive(levelName: "..")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try World(url: archiveURL)
+            XCTFail("Expected invalidLevelName to be thrown")
+        } catch World.WorldError.invalidLevelName {
+            // expected
+        }
+    }
+
+    func testBedrockBackupSlashTraversalName() throws {
+        let (tempDir, archiveURL) = try makeBedrockArchive(levelName: "../../etc/passwd")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try World(url: archiveURL)
+            XCTFail("Expected invalidLevelName to be thrown")
+        } catch World.WorldError.invalidLevelName {
+            // expected
+        }
+    }
+
+    func testBedrockBackupBackslashName() throws {
+        let (tempDir, archiveURL) = try makeBedrockArchive(levelName: "..\\..\\windows\\system32")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try World(url: archiveURL)
+            XCTFail("Expected invalidLevelName to be thrown")
+        } catch World.WorldError.invalidLevelName {
+            // expected
+        }
+    }
+
+    func testBedrockBackupEmptyName() throws {
+        let (tempDir, archiveURL) = try makeBedrockArchive(levelName: "")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try World(url: archiveURL)
+            XCTFail("Expected invalidLevelName to be thrown")
+        } catch World.WorldError.invalidLevelName {
+            // expected
+        }
+    }
+
+    // MARK: - Path Traversal (Java .zip)
+
+    func testJavaBackupValidPath() throws {
+        let (tempDir, archiveURL) = try makeJavaArchive(levelDatPath: "worldname/level.dat")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let world = try World(url: archiveURL)
+        XCTAssertEqual(world.name, "worldname")
+    }
+
+    func testJavaBackupDotDotPath() throws {
+        let (tempDir, archiveURL) = try makeJavaArchive(levelDatPath: "../evil/level.dat")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try World(url: archiveURL)
+            XCTFail("Expected invalidLevelName to be thrown")
+        } catch World.WorldError.invalidLevelName {
+            // expected
+        }
+    }
+
+    func testJavaBackupDeepTraversalPath() throws {
+        let (tempDir, archiveURL) = try makeJavaArchive(levelDatPath: "../../etc/level.dat")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try World(url: archiveURL)
+            XCTFail("Expected invalidLevelName to be thrown")
+        } catch World.WorldError.invalidLevelName {
+            // expected
+        }
+    }
+
+    // MARK: -
 
     func testFetchNameFailure() {
         let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
Fixes two security issues found by code analysis:

1. Path traversal attack. If an attacker has access to your backup folder, they can craft malicious level names. The backup would. Mostly this means someone restoring a corrupted backup could overwrite parts of their Minecraft server container. Not particularly useful to an attacker in the docker case, but good to fix, especially if someone is using the CLI version somewhere.

2. Timing attack on the HTTP token. In principle, someone could work out the HTTP token through repeated brute forcing, and measuring the time it takes to check the token. This would let someone trigger backups at the moment, which isn't particularly harmful (could lead to a denial of service scenario by filling up your drives). Much like the other, good to fix. 