### PR TITLE
Fix Interval Crash

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,7 +5,7 @@ FROM $swift_image AS builder
 WORKDIR /project
 
 # Resolve Packages First
-COPY Package.swift Package.resolved ./
+COPY Package.swift ./
 RUN swift package resolve
 
 # Build

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,13 @@ ARG swift_image=swift:6.3.3
 FROM $swift_image AS builder
 WORKDIR /project
 
-ADD . /project
+# Resolve Packages First
+COPY Package.swift Package.resolved ./
+RUN swift package resolve
+
+# Build
+COPY Sources/ ./Sources/
+COPY Tests/   ./Tests/
 RUN swift build -c release
 
 ###### DEPENDENCY FETCHER

--- a/Examples/bedrock-itzg-ssh-interval/config.yml
+++ b/Examples/bedrock-itzg-ssh-interval/config.yml
@@ -1,0 +1,26 @@
+containers:
+  bedrock:
+    # Backup the world "PublicSMP" on the "server" docker container
+    - name: minecraft-server
+      # Tells the backup service that this container is accessible
+      # using the mc-server-runner SSH functionality.
+      # passwordFile should point to the .remote-console.yaml file in the container
+      ssh: server:2222
+      passwordFile: /server/.remote-console.yaml
+      worlds:
+        - /server/worlds/PublicSMP
+schedule:
+  # This will perform a backup every 3 hours.
+  # At most this will generate 8 backups a day.
+  interval: 3h
+  # Pause at startup for 60s for the server to be fully available,
+  # and then kick off an initial backup.
+  startupDelay: 60s
+  runInitialBackup: true
+trim:
+  # Keep all backups for the last two days (today and yesterday)
+  # Keep at least one backup for the last 14 days
+  # Keep at least two backups per world
+  trimDays: 2
+  keepDays: 14
+  minKeep: 2

--- a/Examples/bedrock-itzg-ssh-interval/docker-compose.yml
+++ b/Examples/bedrock-itzg-ssh-interval/docker-compose.yml
@@ -2,9 +2,12 @@ services:
   backup:
     image: kaiede/minecraft-bedrock-backup
     restart: always
+    container_name: minecraft-backup
     # Make sure the minecraft image starts before the backup
     depends_on:
-      - "server"
+      server:
+        condition: service_healthy
+        restart: true
     environment:
       # Local timezone to reduce confusion
       TZ: ${TZ:-America/Los_Angeles}
@@ -12,31 +15,28 @@ services:
       - minecraft-backup:/config
       - ./config.yml:/config/config.yml:ro
       - minecraft-server-backups:/data
-      - minecraft-server-data:/server:ro
+      - bedrock-server-data:/server:ro
 
   server:
-    image: itzg/minecraft-server
+    image: itzg/minecraft-bedrock-server
+    restart: always
     container_name: minecraft-server
     # Reminder that port 2222 is used inside this stack.
     expose:
-      - 25575
+      - 2222
     # Make the minecraft server port public
     ports:
-      - 25565:25565
+      - 19132:19132/udp
     environment:
-      # Enable RCON
-      ENABLE_RCON: "TRUE"
-      # Server Settings
-      TYPE: "FABRIC"
+      # Enable SSH
+      ENABLE_SSH: "TRUE"
+      # Server settings
       EULA: "TRUE"
-      MAX_PLAYERS: 6
-      VIEW_DISTANCE: 20
-      LEVEL: "PublicSMP"
-      MOTD: "Public SMP Server"
-      MEMORY: "2G"
+      LEVEL_NAME: ${LEVEL_NAME:-PublicSMP}
     volumes:
-      - minecraft-server-data:/data
-    restart: unless-stopped
+      - bedrock-server-data:/data
+    stdin_open: true
+    tty: true
 
   restore:
     image: kaiede/minecraft-bedrock-backup
@@ -47,26 +47,26 @@ services:
     volumes:
       - ./config.yml:/config/config.yml:ro
       - minecraft-server-backups:/data:ro
-      - minecraft-server-data:/server
+      - bedrock-server-data:/server
     stdin_open: true
     tty: true
 
 volumes:
   # Allows backup to store persistent configuration for itself
   minecraft-backup:
-  
+
   # Volume for backup data.
   minecraft-server-backups:
     driver: local
     driver_opts:
       type: none
       o: bind
-      device: ${BEDROCKIFIER_BACKUPS_DIR:-/opt/minecraft/backups}
+      device: ${BEDROCKIFIER_BACKUPS_DIR:-${PWD}/data/backups}
 
   # Minecraft Server Data
-  minecraft-server-data:
+  bedrock-server-data:
     driver: local
     driver_opts:
       type: none
       o: bind
-      device: ${MINECRAFT_SERVER_DATA_DIR:-/opt/minecraft/public}
+      device: ${MINECRAFT_SERVER_DATA_DIR:-${PWD}/data/public}

--- a/Examples/bedrock-itzg-ssh-login/config.yml
+++ b/Examples/bedrock-itzg-ssh-login/config.yml
@@ -10,9 +10,16 @@ containers:
       worlds:
         - /server/worlds/PublicSMP
 schedule:
-  # This will perform a backup every 3 hours.
-  # At most this will generate 8 backups a day.
-  interval: 3h
+  # Trigger a backup on player login or logout, at most 3 hours apart.
+  # Also trigger a backup every day at 0100.
+  onPlayerLogin: true
+  onPlayerLogout: true
+  minInterval: 3h
+  daily: 01:00
+  # Pause at startup for 60s for the server to be fully available,
+  # and then kick off an initial backup.
+  startupDelay: 60s
+  runInitialBackup: true
 trim:
   # Keep all backups for the last two days (today and yesterday)
   # Keep at least one backup for the last 14 days

--- a/Examples/bedrock-itzg-ssh-login/docker-compose.yml
+++ b/Examples/bedrock-itzg-ssh-login/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     container_name: minecraft-backup
     # Make sure the minecraft image starts before the backup
     depends_on:
-      - "server"
+      server:
+        condition: service_healthy
+        restart: true
     environment:
       # Local timezone to reduce confusion
       TZ: ${TZ:-America/Los_Angeles}
@@ -52,14 +54,14 @@ services:
 volumes:
   # Allows backup to store persistent configuration for itself
   minecraft-backup:
-   
+
   # Volume for backup data.
   minecraft-server-backups:
     driver: local
     driver_opts:
       type: none
       o: bind
-      device: ${BEDROCKIFIER_BACKUPS_DIR:-/opt/minecraft/backups}
+      device: ${BEDROCKIFIER_BACKUPS_DIR:-${PWD}/data/backups}
 
   # Minecraft Server Data
   bedrock-server-data:
@@ -67,4 +69,4 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: ${MINECRAFT_SERVER_DATA_DIR:-/opt/bedrock/public}
+      device: ${MINECRAFT_SERVER_DATA_DIR:-${PWD}/data/public}

--- a/Examples/bedrock-itzg-ssh-multiple/docker-compose.yml
+++ b/Examples/bedrock-itzg-ssh-multiple/docker-compose.yml
@@ -4,8 +4,12 @@ services:
     restart: always
     # Make sure the minecraft images start before the backup
     depends_on:
-      - "public"
-      - "private"
+      public:
+        condition: service_healthy
+        restart: true
+      private:
+        condition: service_healthy
+        restart: true
     environment:
       # Local timezone to reduce confusion
       TZ: ${TZ:-America/Los_Angeles}
@@ -88,14 +92,14 @@ services:
 volumes:
   # Allows backup to store persistent configuration for itself
   minecraft-backup:
-  
+
   # Volume for backup data.
   minecraft-server-backups:
     driver: local
     driver_opts:
       type: none
       o: bind
-      device: ${BEDROCKIFIER_BACKUPS_DIR:-/opt/minecraft/backups}
+      device: ${BEDROCKIFIER_BACKUPS_DIR:-${PWD}/data/backups}
 
   # Private/Internal Server Data
   minecraft-private-data:
@@ -103,7 +107,7 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: ${PRIVATE_SERVER_DATA_DIR:-/opt/bedrock/private}
+      device: ${PRIVATE_SERVER_DATA_DIR:-${PWD}/data/private}
 
   # Public Server Data
   minecraft-public-data:
@@ -111,4 +115,4 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: ${PUBLIC_SERVER_DATA_DIR:-/opt/bedrock/public}
+      device: ${PUBLIC_SERVER_DATA_DIR:-${PWD}/data/public}

--- a/Examples/java-itzg-rcon-lastlogout/config.yml
+++ b/Examples/java-itzg-rcon-lastlogout/config.yml
@@ -22,6 +22,10 @@ schedule:
   daily: 01:00
   onLastLogout: true
   minInterval: 4h
+  # Pause at startup for 60s for the server to be fully available,
+  # and then kick off an initial backup.
+  startupDelay: 60s
+  runInitialBackup: true
 trim:
   # Keep all backups for the last two days (today and yesterday)
   # Keep at least one backup for the last 14 days

--- a/Examples/java-itzg-rcon-lastlogout/docker-compose.yml
+++ b/Examples/java-itzg-rcon-lastlogout/docker-compose.yml
@@ -1,0 +1,72 @@
+services:
+  backup:
+    image: kaiede/minecraft-bedrock-backup
+    restart: always
+    # Make sure the minecraft image starts before the backup
+    depends_on:
+      - "server"
+    environment:
+      # Local timezone to reduce confusion
+      TZ: ${TZ:-America/Los_Angeles}
+    volumes:
+      - minecraft-backup:/config
+      - ./config.yml:/config/config.yml:ro
+      - minecraft-server-backups:/data
+      - minecraft-server-data:/server:ro
+
+  server:
+    image: itzg/minecraft-server
+    container_name: minecraft-server
+    # Reminder that port 2222 is used inside this stack.
+    expose:
+      - 25575
+    # Make the minecraft server port public
+    ports:
+      - 25565:25565
+    environment:
+      # Enable RCON
+      ENABLE_RCON: "TRUE"
+      # Server Settings
+      TYPE: "FABRIC"
+      EULA: "TRUE"
+      MAX_PLAYERS: 6
+      VIEW_DISTANCE: 20
+      LEVEL: "PublicSMP"
+      MOTD: "Public SMP Server"
+      MEMORY: "2G"
+    volumes:
+      - minecraft-server-data:/data
+    restart: unless-stopped
+
+  restore:
+    image: kaiede/minecraft-bedrock-backup
+    profiles:
+      - restore
+    entrypoint: ["/opt/bedrock/bedrockifier", "restore"]
+    network_mode: "none"
+    volumes:
+      - ./config.yml:/config/config.yml:ro
+      - minecraft-server-backups:/data:ro
+      - minecraft-server-data:/server
+    stdin_open: true
+    tty: true
+
+volumes:
+  # Allows backup to store persistent configuration for itself
+  minecraft-backup:
+
+  # Volume for backup data.
+  minecraft-server-backups:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${BEDROCKIFIER_BACKUPS_DIR:-${PWD}/data/backups}
+
+  # Minecraft Server Data
+  minecraft-server-data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${MINECRAFT_SERVER_DATA_DIR:-${PWD}/data/public}

--- a/Examples/java-itzg-ssh-lastlogout/config.yml
+++ b/Examples/java-itzg-ssh-lastlogout/config.yml
@@ -14,7 +14,7 @@ containers:
         - /server/logs
         - /server/mods
 schedule:
-  # This will trigger a backup every time the last player logs out. 
+  # This will trigger a backup every time the last player logs out.
   # At most, one backup every 4 hours will be made when the player logs out.
   # There is also one daily backup made at 1am every day.
   # This will produce a maximum of 7 backups a day, but will always produce
@@ -22,6 +22,10 @@ schedule:
   daily: 01:00
   onLastLogout: true
   minInterval: 4h
+  # Pause at startup for 60s for the server to be fully available,
+  # and then kick off an initial backup.
+  startupDelay: 60s
+  runInitialBackup: true
 trim:
   # Keep all backups for the last two days (today and yesterday)
   # Keep at least one backup for the last 14 days

--- a/Examples/java-itzg-ssh-lastlogout/docker-compose.yml
+++ b/Examples/java-itzg-ssh-lastlogout/docker-compose.yml
@@ -54,14 +54,14 @@ services:
 volumes:
   # Allows backup to store persistent configuration for itself
   minecraft-backup:
-  
+
   # Volume for backup data.
   minecraft-server-backups:
     driver: local
     driver_opts:
       type: none
       o: bind
-      device: ${BEDROCKIFIER_BACKUPS_DIR:-/opt/minecraft/backups}
+      device: ${BEDROCKIFIER_BACKUPS_DIR:-${PWD}/data/backups}
 
   # Minecraft Server Data
   minecraft-server-data:
@@ -69,4 +69,4 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: ${MINECRAFT_SERVER_DATA_DIR:-/opt/minecraft/public}
+      device: ${MINECRAFT_SERVER_DATA_DIR:-${PWD}/data/public}

--- a/Sources/BedrockifierLib/Service/BackupService.swift
+++ b/Sources/BedrockifierLib/Service/BackupService.swift
@@ -44,6 +44,7 @@ public final class BackupService {
 
     typealias ServiceContext = BasicRequestContext
 
+    private static let defaultSleepInterval = Duration.seconds(600)
     public static let logger = Logger(label: "bedrockifier.service")
     private static let backupPriority = TaskPriority.background
 
@@ -197,23 +198,7 @@ public final class BackupService {
             }
         }
 
-        let mainTask = Task(priority: BackupService.backupPriority) {
-            try await runIntervalBackups()
-        }
-
-        let interruptSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .global())
-        interruptSource.setEventHandler {
-            BackupService.logger.warning("Received SIGINT")
-            mainTask.cancel()
-        }
-
-        let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .global())
-        termSource.setEventHandler {
-            BackupService.logger.warning("Received SIGTERM")
-            mainTask.cancel()
-        }
-
-        try await mainTask.value
+        try await runIntervalBackupsOrSleep()
     }
 
     private func connectContainers() async throws {
@@ -245,16 +230,17 @@ public final class BackupService {
         }
     }
 
-    private func runIntervalBackups() async throws {
-        guard let interval = try getBackupInterval() else {
-            BackupService.logger.error("Unable to Parse Backup Interval")
-            throw ServiceError.noBackupInterval
-        }
-
-        BackupService.logger.info("Backup Interval: \(interval) seconds")
-        let timer = AsyncTimerSequence(interval: .seconds(interval), clock: .continuous)
-        for await _ in timer {
-            await self.backupActor.backupAllContainers(isDaily: false)
+    private func runIntervalBackupsOrSleep() async throws {
+        if let interval = try? getBackupInterval() {
+            BackupService.logger.info("Backup Interval: \(interval) seconds")
+            let timer = AsyncTimerSequence(interval: .seconds(interval), clock: .continuous)
+            for await _ in timer {
+                await self.backupActor.backupAllContainers(isDaily: false)
+            }
+        } else {
+            repeat {
+                try await Task.sleep(for: BackupService.defaultSleepInterval)
+            } while !Task.isCancelled
         }
     }
 

--- a/Wiki/Development.md
+++ b/Wiki/Development.md
@@ -1,0 +1,35 @@
+### Validating Changes
+
+Unit tests can do the work to make sure basic functionality isn't impacted:
+
+`swift test` 
+
+However, to get better coverage of the different configurations people might use in practice, it helps to run a variety of configurations. With a little effort, it's possible to use the examples in this repository directly as end-to-end tests. From the root directory, run these steps.
+
+```
+# Build a docker image.
+./build-docker
+
+# Tag the image to match the examples, or modify the examples to match the tag
+docker tag <generated image tag> kaiede/minecraft-bedrock-backup:latest
+
+# Go to the example 
+cd Examples/<example>
+mkdir -p data/backups data/public
+
+# Bring up the stack
+docker compose up
+```
+
+The current examples all kick off an initial backup after a 60 second delay. This lets you catch the most egregious integration problems quickly. But since this brings up a full minecraft stack, you can login, logout, and generally play around to ensure that logic works. 
+
+The most important examples to check are:
+
+* bedrock-itzg-ssh-interval
+* bedrock-itgz-ssh-login
+* java-itzg-rcon-lastlogout
+* java-itzg-ssh-lastlogout
+
+This ensures that Java + Bedrock are tested, as well as Interval + Event-Based schedules.
+
+Note: Podman can be used for testing here, but podman compose doesn't seem to fully support dependencies that are used in the compose examples. So it will not wait for the server to be healthy before it starts the backup service, and may kick off the backup service first.

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -11,8 +11,7 @@ containerPath=$(which container)
 if [[ "$podmanPath" != "" ]]; then
     echo "Using Podman."
     toolPath=$podmanPath
-fi
-if [[ "$containerPath" != "" ]]; then
+elif [[ "$containerPath" != "" ]]; then
     echo "Using Apple Containers."
     toolPath=$containerPath
 fi


### PR DESCRIPTION
On startup, the main thread would create a task to run interval backups, and then wait on it. This was part of the modernization of threading to use Swift Concurrency. This was the wrong approach, as event-based backups don't require an interval. This would cause runIntervalBackups to throw an error. 

The fix is to do what should have been done: the main thread will go into a loop after startup, by calling and waiting on runIntervalBackupsOrSleep(). This modified function will create a stream of events to trigger interval backups, or simply sleep in loops of 600 seconds (10 minutes), waiting for the main task to be cancelled. 

To try to make validation easier, I've made changes to the examples so that they can be used to bring up a few different configurations and used for testing as-is. I've also added documentation to the Wiki to cover how to do this as a reminder for maintainers down the road. 

Fixes #204